### PR TITLE
Redesign Generation Results review workspace

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ import {
   excludeProvisionedCodeFiles,
   findMissingCodeFiles,
 } from "./src/flutterFlowCodeFileProvisioning.js";
+import { buildReviewPresentation } from "./src/reviewPresentation.js";
 import { buildFlutterFlowSyncMetadata } from "./src/flutterFlowSyncMetadata.js";
 import {
   mergeDependenciesIntoYaml,
@@ -1222,8 +1223,6 @@ function updateKeyStatus(provider, statusElementId) {
 }
 
 function updateDeployButtonVisibility() {
-  const flutterFlowConfigured =
-    hasStoredKey("flutterflow") && hasStoredKey("flutterflow_project_id");
   const hasGeneratedCode =
     pipelineState.step2Result && pipelineState.step2Result.length > 0;
 
@@ -1234,10 +1233,7 @@ function updateDeployButtonVisibility() {
   // without closing the results.
   if (runBtn) runBtn.classList.remove("hidden");
   if (deployBtn) {
-    deployBtn.classList.toggle(
-      "hidden",
-      !(flutterFlowConfigured && hasGeneratedCode),
-    );
+    deployBtn.classList.toggle("hidden", !hasGeneratedCode);
   }
 }
 
@@ -1505,6 +1501,7 @@ let pipelineState = {
   artifactBundle: null,
   bundleReview: null,
   selectedArtifactId: null,
+  resultsViewMode: "summary",
   currentStep: 0,
   isRunning: false,
 };
@@ -1517,6 +1514,7 @@ function resetPipelineResults() {
   pipelineState.artifactBundle = null;
   pipelineState.bundleReview = null;
   pipelineState.selectedArtifactId = null;
+  pipelineState.resultsViewMode = "summary";
 }
 
 function updateBundleSpecFromArchitectResult() {
@@ -4667,6 +4665,7 @@ function showPaywallExhausted(count, limit, options = {}) {
 
   const resultsView = document.getElementById('results-view')
   if (resultsView) resultsView.classList.remove('visible')
+  document.body.classList.remove("results-fullscreen")
 
   const pipelineProgress = document.getElementById('pipeline-progress')
   if (pipelineProgress) pipelineProgress.classList.remove('visible')
@@ -5602,6 +5601,7 @@ function showPipelineProgress() {
 
   if (readyState) readyState.classList.add("hidden");
   if (resultsView) resultsView.classList.remove("visible");
+  document.body.classList.remove("results-fullscreen");
   if (progress) progress.classList.add("visible");
 
   pipelineStartTime = Date.now();
@@ -5688,80 +5688,239 @@ function hidePipelineProgress() {
   }, 400);
 }
 
-function renderSelectedArtifactReview(fallbackAuditContent = "") {
-  const selectedArtifact = getSelectedArtifact();
-  const reviewArtifact = pipelineState.bundleReview?.artifacts?.find(
-    (artifact) => artifact.id === selectedArtifact.id,
-  );
-  const review = reviewArtifact?.review || selectedArtifact.review;
+function reviewStatusIcon(status, className = "") {
+  const paths = {
+    pass: `<path d="M20 6 9 17l-5-5"/>`,
+    warning: `<path d="M12 9v4m0 4h.01"/><path d="M10.3 3.6 2.2 18a2 2 0 0 0 1.7 3h16.2a2 2 0 0 0 1.7-3L13.7 3.6a2 2 0 0 0-3.4 0Z"/>`,
+    fail: `<path d="m15 9-6 6m0-6 6 6"/><circle cx="12" cy="12" r="9"/>`,
+  };
+  return `<svg class="review-status-icon ${className}" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${paths[status] || paths.warning}</svg>`;
+}
 
-  if (!review || typeof review === "string") {
-    return typeof review === "string" ? renderMarkdownAudit(review) : fallbackAuditContent;
-  }
+function reviewStatusLabel(status) {
+  return {
+    pass: "Passed review",
+    warning: "Needs attention",
+    fail: "Blocking issues",
+  }[status] || "Needs attention";
+}
 
-  const findings = Array.isArray(review.findings) ? review.findings : [];
-  const status = review.status || "pending";
-  const findingHtml = findings.length > 0
-    ? findings.map((finding) => `
-      <div class="audit-item">
-        <strong>${escapeHtml(finding.severity || "info")}</strong>: ${escapeHtml(finding.message || "")}
-        ${finding.suggestion ? `<br><span>${escapeHtml(finding.suggestion)}</span>` : ""}
-      </div>
-    `).join("")
-    : `<div class="audit-item">No artifact-specific findings.</div>`;
+function getReviewPresentation() {
+  return buildReviewPresentation({
+    bundle: pipelineState.artifactBundle,
+    reviewResult: pipelineState.step3Result,
+  });
+}
 
+function renderFinding(finding) {
   return `
-    <div class="audit-section">
-      <h3>${escapeHtml(selectedArtifact.artifactName)} review: ${escapeHtml(status)}</h3>
-      ${findingHtml}
+    <div class="review-finding review-finding-${escapeAttr(finding.severity)}">
+      ${reviewStatusIcon(finding.severity)}
+      <div>
+        <div class="review-finding-message">${escapeHtml(finding.message)}</div>
+        ${finding.suggestion ? `<div class="review-finding-suggestion">${escapeHtml(finding.suggestion)}</div>` : ""}
+        <span class="review-source">${escapeHtml(finding.source)}</span>
+      </div>
     </div>
   `;
 }
 
-function renderBundleControls() {
-  const bundle = pipelineState.artifactBundle;
-  const strip = document.getElementById("bundle-strip");
-  const tabs = document.getElementById("artifact-tabs");
-  const artifactCount = document.getElementById("bundle-artifact-count");
-  const deployableCount = document.getElementById("bundle-deployable-count");
-  const warningCount = document.getElementById("bundle-warning-count");
+function renderManualStep(step) {
+  return `
+    <li class="manual-step">
+      <div>
+        <strong>${escapeHtml(step.title)}</strong>
+        ${step.detail && step.detail !== step.title ? `<p>${escapeHtml(step.detail)}</p>` : ""}
+      </div>
+    </li>
+  `;
+}
 
-  if (!bundle || !Array.isArray(bundle.artifacts) || bundle.artifacts.length <= 1) {
+function renderSummaryDetail(presentation) {
+  const summaryDetail = document.getElementById("results-summary-detail");
+  const resultsTitle = document.getElementById("results-title");
+  if (!summaryDetail) return;
+  if (resultsTitle) {
+    resultsTitle.textContent = presentation.title;
+  }
+
+  const score = presentation.score;
+  const scoreTone = score == null
+    ? presentation.status
+    : score >= 80 ? "pass" : score >= 60 ? "warning" : "fail";
+  const scoreLabel = score == null
+    ? "Not scored"
+    : score >= 80 ? "Strong" : score >= 60 ? "Needs work" : "High risk";
+  const findings = presentation.findings.length
+    ? `
+      <ul class="summary-findings">
+        ${presentation.findings.map((finding) => `
+          <li class="summary-finding-${escapeAttr(finding.severity)}">
+            ${reviewStatusIcon(finding.severity)}
+            <span>${escapeHtml(finding.message)}</span>
+          </li>
+        `).join("")}
+      </ul>
+    `
+    : "";
+  const manualSteps = presentation.manualSteps.length
+    ? `
+      <section class="summary-manual-callout">
+        <h3>${reviewStatusIcon("warning")} Complete in FlutterFlow</h3>
+        <ul>
+          ${presentation.manualSteps.map((step) => `
+            <li>
+              <strong>${escapeHtml(step.title)}</strong>
+              ${step.detail && step.detail !== step.title ? `<span>${escapeHtml(step.detail)}</span>` : ""}
+            </li>
+          `).join("")}
+        </ul>
+      </section>
+    `
+    : "";
+
+  summaryDetail.innerHTML = `
+    <section class="review-summary">
+      <div class="review-summary-copy">
+        <p class="review-summary-text">${escapeHtml(presentation.summary)}</p>
+        ${findings}
+        ${manualSteps}
+      </div>
+      <div class="review-score-column">
+        <aside class="review-score review-score-${escapeAttr(scoreTone)}" aria-label="${score == null ? "Review not scored" : `Review score ${score} out of 100`}">
+          <span class="review-score-label">Score</span>
+          <strong>${score == null ? "—" : escapeHtml(score)}</strong>
+          <span class="review-score-total">${score == null ? "Not scored" : "out of 100"}</span>
+          <span class="review-score-status">${escapeHtml(scoreLabel)}</span>
+        </aside>
+        <div class="review-score-feedback">
+          <span>Is the generated code correct?</span>
+          <div class="review-score-feedback-controls">
+            <button class="feedback-btn" id="btn-feedback-up" onclick="submitResultsFeedback('up')" title="Yes">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 9V5a3 3 0 00-3-3l-4 9v11h11.28a2 2 0 002-1.7l1.38-9a2 2 0 00-2-2.3H14z"/></svg>
+            </button>
+            <button class="feedback-btn" id="btn-feedback-down" onclick="submitResultsFeedback('down')" title="No">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 15v4a3 3 0 003 3l4-9V2H5.72a2 2 0 00-2 1.7l-1.38 9a2 2 0 002 2.3H10z"/></svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderSelectedArtifactReview(presentation) {
+  const selectedArtifact = presentation.artifacts.find(
+    (artifact) => artifact.id === pipelineState.selectedArtifactId,
+  ) || presentation.artifacts[0];
+  if (!selectedArtifact) return "";
+
+  const findings = selectedArtifact.findings.length
+    ? selectedArtifact.findings.map(renderFinding).join("")
+    : `<div class="review-empty-state">${reviewStatusIcon("pass")} No file-specific findings were returned.</div>`;
+  const dependencies = selectedArtifact.dependencies?.length
+    ? selectedArtifact.dependencies.map((dependency) => `
+      <li><code>${escapeHtml(dependency.name)}${dependency.version ? ` ${escapeHtml(dependency.version)}` : ""}</code>${dependency.reason ? `<p>${escapeHtml(dependency.reason)}</p>` : ""}</li>
+    `).join("")
+    : `<li class="review-muted">No external packages</li>`;
+  const imports = selectedArtifact.imports?.length
+    ? selectedArtifact.imports.map((item) => `<code>${escapeHtml(item)}</code>`).join("")
+    : `<span class="review-muted">No imports returned</span>`;
+  const publicApi = selectedArtifact.publicApi?.length
+    ? selectedArtifact.publicApi.map((item) => `<code>${escapeHtml(item)}</code>`).join("")
+    : `<span class="review-muted">No public API signature returned</span>`;
+  const relationships = selectedArtifact.relationships.length
+    ? selectedArtifact.relationships.map((relationship) => `
+      <li><strong>${escapeHtml(relationship.from || "Bundle")}</strong> ${escapeHtml(relationship.type)} <strong>${escapeHtml(relationship.to || "Bundle")}</strong>${relationship.description ? `<p>${escapeHtml(relationship.description)}</p>` : ""}</li>
+    `).join("")
+    : `<li class="review-muted">No relationships for this file</li>`;
+
+  return `
+    <div class="file-review-header file-review-${selectedArtifact.status}">
+      <div>
+        <span class="file-review-status">${reviewStatusIcon(selectedArtifact.status)} ${escapeHtml(reviewStatusLabel(selectedArtifact.status))}</span>
+        <h3>${escapeHtml(selectedArtifact.artifactName)}</h3>
+        ${selectedArtifact.description ? `<p>${escapeHtml(selectedArtifact.description)}</p>` : ""}
+      </div>
+      <div class="file-review-meta">
+        <span>${escapeHtml(selectedArtifact.artifactType)}</span>
+        <span>${escapeHtml(selectedArtifact.fileName)}</span>
+      </div>
+    </div>
+    <section class="file-review-section">
+      <h4>Code Review findings</h4>
+      ${findings}
+    </section>
+    ${selectedArtifact.manualSteps.length ? `
+      <section class="file-review-section file-manual-section">
+        <h4>Manual FlutterFlow steps for this file</h4>
+        <ol>${selectedArtifact.manualSteps.map(renderManualStep).join("")}</ol>
+      </section>
+    ` : ""}
+    <details class="file-technical-details">
+      <summary>File details</summary>
+      <div class="file-detail-grid">
+        <section class="file-review-section">
+          <h4>Dependencies</h4>
+          <ul class="dependency-list">${dependencies}</ul>
+        </section>
+        <section class="file-review-section">
+          <h4>Deployment</h4>
+          <dl class="file-deploy-facts">
+            <div><dt>Status</dt><dd>${escapeHtml(selectedArtifact.deployStatus || "pending")}</dd></div>
+            <div><dt>Order</dt><dd>${selectedArtifact.index + 1} of ${presentation.artifacts.length}</dd></div>
+            <div><dt>Path hint</dt><dd>${escapeHtml(selectedArtifact.pathHint || "Not returned")}</dd></div>
+          </dl>
+        </section>
+      </div>
+      <section class="file-review-section">
+        <h4>Public API</h4>
+        <div class="code-chip-list">${publicApi}</div>
+      </section>
+      <section class="file-review-section">
+        <h4>Imports</h4>
+        <div class="code-chip-list">${imports}</div>
+      </section>
+      <section class="file-review-section">
+        <h4>Relationships</h4>
+        <ul class="file-relationship-list">${relationships}</ul>
+      </section>
+    </details>
+  `;
+}
+
+function renderBundleControls(presentation) {
+  const strip = document.getElementById("bundle-strip");
+  const summaryTab = document.getElementById("results-summary-tab");
+  const tabs = document.getElementById("artifact-tabs");
+  const count = document.getElementById("results-file-count");
+  if (summaryTab) {
+    summaryTab.classList.toggle("active", pipelineState.resultsViewMode === "summary");
+  }
+  if (!presentation.artifacts.length) {
+    if (count) count.textContent = "0 files";
     if (strip) strip.classList.remove("visible");
     if (tabs) tabs.innerHTML = "";
     return;
   }
 
-  const compatibilityFindings = bundle.metadata?.compatibility?.findings || [];
-  const errorArtifactIds = new Set(
-    compatibilityFindings
-      .filter((finding) => finding.severity === "error")
-      .map((finding) => finding.artifactId),
-  );
-
-  if (artifactCount) artifactCount.textContent = String(bundle.artifacts.length);
-  if (deployableCount) {
-    deployableCount.textContent = String(
-      bundle.artifacts.filter((artifact) => !errorArtifactIds.has(artifact.id)).length,
-    );
+  if (count) {
+    const fileCount = presentation.artifacts.length;
+    count.textContent = `${fileCount} ${fileCount === 1 ? "file" : "files"}`;
   }
-  if (warningCount) {
-    warningCount.textContent = String(
-      (bundle.warnings || []).length
-        + compatibilityFindings.filter((finding) => finding.severity !== "error").length,
-    );
-  }
-
   if (tabs) {
-    tabs.innerHTML = bundle.artifacts.map((artifact) => `
+    tabs.innerHTML = presentation.artifacts.map((artifact) => `
       <button
         type="button"
-        class="artifact-tab${artifact.id === pipelineState.selectedArtifactId ? " active" : ""}"
+        class="artifact-tab${pipelineState.resultsViewMode === "file" && artifact.id === pipelineState.selectedArtifactId ? " active" : ""}"
         data-artifact-id="${escapeAttr(artifact.id)}"
-        title="${escapeAttr(artifact.fileName || artifact.artifactName)}"
+        title="${escapeAttr(`${reviewStatusLabel(artifact.status)} · ${artifact.fileName || artifact.artifactName}`)}"
       >
-        <span class="artifact-tab-name">${escapeHtml(artifact.artifactName)}</span>
-        <span class="artifact-tab-meta">${escapeHtml(artifact.artifactType)} · ${escapeHtml(artifact.fileName)}</span>
+        <span class="artifact-tab-status status-${escapeAttr(artifact.status)}">${reviewStatusIcon(artifact.status)}</span>
+        <span>
+          <span class="artifact-tab-name">${escapeHtml(artifact.artifactName)}</span>
+          <span class="artifact-tab-meta">${escapeHtml(artifact.artifactType)}</span>
+        </span>
       </button>
     `).join("");
     tabs.onclick = (event) => {
@@ -5775,33 +5934,48 @@ function renderBundleControls() {
   if (strip) strip.classList.add("visible");
 }
 
-function updateSelectedArtifactPanels(fallbackAuditContent = "") {
+function updateSelectedArtifactPanels() {
+  document.body.classList.add("results-fullscreen");
+  document.body.classList.toggle(
+    "results-with-sidebar",
+    IS_DEV && new URLSearchParams(window.location.search).get("debugSidebar") === "1",
+  );
   const resultsView = document.getElementById("results-view");
   const codeOutput = document.getElementById("results-code-output");
   const auditOutput = document.getElementById("results-audit-output");
+  const summaryDetail = document.getElementById("results-summary-detail");
+  const artifactSplit = document.getElementById("artifact-results-split");
+  const presentation = getReviewPresentation();
   const selectedCode = getSelectedArtifactCode();
 
-  // Code panel uses highlighted code (already sanitized by highlightCode)
+  renderSummaryDetail(presentation);
+  renderBundleControls(presentation);
+
   if (codeOutput) codeOutput.textContent = "";
   if (codeOutput) {
-    // Use the same highlightCode function used elsewhere in this codebase
     const highlighted = highlightCode(selectedCode);
-    // highlightCode returns hljs-processed HTML which is safe (generated by highlight.js)
     codeOutput.innerHTML = highlighted; // eslint-disable-line -- highlight.js output
   }
-  // renderMarkdownAudit escapes the model output before adding its own markup.
   if (auditOutput) {
-    auditOutput.innerHTML = renderSelectedArtifactReview(fallbackAuditContent); // eslint-disable-line -- renderMarkdownAudit output
+    auditOutput.innerHTML = renderSelectedArtifactReview(presentation);
+  }
+  if (summaryDetail) {
+    summaryDetail.classList.toggle("hidden", pipelineState.resultsViewMode !== "summary");
+  }
+  if (artifactSplit) {
+    artifactSplit.classList.toggle("hidden", pipelineState.resultsViewMode !== "file");
   }
   if (resultsView) resultsView.classList.add("visible");
-  renderBundleControls();
 }
 
 function showResultsView(codeContent, auditContent) {
   if (!pipelineState.selectedArtifactId) {
     pipelineState.selectedArtifactId = getPrimaryArtifact(pipelineState.artifactBundle).id;
   }
-  updateSelectedArtifactPanels(auditContent);
+  pipelineState.resultsViewMode = "summary";
+  document.body.classList.add("results-fullscreen");
+  updateSelectedArtifactPanels();
+  updateDeployButtonVisibility();
 
   // Reset feedback buttons
   const upBtn = document.getElementById("btn-feedback-up");
@@ -5874,6 +6048,19 @@ function showDebugMultiArtifactResults() {
   pipelineState.step3Result = JSON.stringify({
     schemaVersion: "artifact-bundle/v1",
     id: "debug-agent-ui",
+    overallReview: {
+      status: "warn",
+      score: 86,
+      summary: "The bundle structure is sound. AgentTimeline still needs its event rendering completed before release.",
+      manualActions: [
+        {
+          title: "Wire the generated AgentTimeline into the target page",
+          detail: "Add the custom widget in FlutterFlow and bind its event data.",
+          location: "UI Builder > Custom Widgets",
+          timing: "after deploy",
+        },
+      ],
+    },
     artifacts: [
       {
         id: "custom-class-agent-event",
@@ -5914,7 +6101,13 @@ function showDebugMultiArtifactResults() {
 
 function selectArtifact(artifactId) {
   pipelineState.selectedArtifactId = artifactId;
-  updateSelectedArtifactPanels(renderMarkdownAudit(pipelineState.step3Result || ""));
+  pipelineState.resultsViewMode = "file";
+  updateSelectedArtifactPanels();
+}
+
+function selectResultsSummary() {
+  pipelineState.resultsViewMode = "summary";
+  updateSelectedArtifactPanels();
 }
 
 function copyResultsCode() {
@@ -5975,6 +6168,7 @@ function hideErrorInputPanel() {
 
 window.copyResultsCode = copyResultsCode;
 window.selectArtifact = selectArtifact;
+window.selectResultsSummary = selectResultsSummary;
 window.submitResultsFeedback = submitResultsFeedback;
 window.showErrorInputPanel = showErrorInputPanel;
 window.hideErrorInputPanel = hideErrorInputPanel;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FlutterFlow Custom Code Connect</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <meta name="description" content="Generate FlutterFlow-ready custom functions, actions, widgets, and code files that actually compile." />
     <link rel="canonical" href="https://customcode.connectio.com.au/" />
     <meta property="og:type" content="website" />
@@ -640,43 +641,13 @@
       }
       .bundle-strip {
         display: none;
-        grid-template-columns: minmax(220px, 0.7fr) minmax(0, 1.3fr);
-        gap: 16px;
-        padding: 14px 24px;
+        padding: 12px 24px;
         border-bottom: 1px solid var(--border);
-        background: #fff;
+        background: #f8fafc;
         flex-shrink: 0;
       }
       .bundle-strip.visible {
-        display: grid;
-      }
-      .bundle-summary {
-        display: grid;
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-        gap: 8px;
-      }
-      .bundle-stat {
-        min-width: 0;
-        padding: 10px;
-        border: 1px solid var(--border);
-        border-radius: 8px;
-        background: #fafbfc;
-      }
-      .bundle-stat-value {
         display: block;
-        font-size: 18px;
-        font-weight: 700;
-        color: var(--navy);
-        line-height: 1.1;
-      }
-      .bundle-stat-label {
-        display: block;
-        margin-top: 4px;
-        font-size: 10px;
-        font-weight: 700;
-        color: var(--sublabel);
-        text-transform: uppercase;
-        letter-spacing: 0.08em;
       }
       .artifact-tabs {
         display: flex;
@@ -685,17 +656,20 @@
         padding-bottom: 2px;
       }
       .artifact-tab {
+        display: flex;
         flex: 0 0 auto;
         min-width: 168px;
         max-width: 240px;
         text-align: left;
         padding: 10px 12px;
         border: 1px solid var(--border);
-        border-radius: 8px;
+        border-radius: 10px;
         background: #fff;
         color: var(--navy);
         cursor: pointer;
         transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+        align-items: center;
+        gap: 9px;
       }
       .artifact-tab:hover {
         border-color: #cbd5e1;
@@ -706,6 +680,17 @@
         background: #eef2ff;
         box-shadow: inset 0 0 0 1px #6366f1;
       }
+      .artifact-tab-status {
+        width: 26px;
+        height: 26px;
+        display: grid;
+        place-items: center;
+        flex: 0 0 26px;
+        border-radius: 8px;
+      }
+      .artifact-tab-status.status-pass { color: #15803d; background: #dcfce7; }
+      .artifact-tab-status.status-warning { color: #b45309; background: #fef3c7; }
+      .artifact-tab-status.status-fail { color: #b91c1c; background: #fee2e2; }
       .artifact-tab-name {
         display: block;
         overflow: hidden;
@@ -723,6 +708,116 @@
         font-size: 11px;
         color: var(--sublabel);
       }
+      .review-status-icon {
+        width: 16px;
+        height: 16px;
+        flex: 0 0 16px;
+      }
+      .manual-step {
+        display: flex;
+        align-items: flex-start;
+        gap: 9px;
+        color: #78350f;
+        font-size: 12px;
+      }
+      .manual-step p { margin-top: 3px; color: #92400e; line-height: 1.45; }
+      .results-summary-detail {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+        padding: 20px 24px;
+        background: #fff;
+      }
+      .file-review-section h4 {
+        margin-bottom: 9px;
+        color: #475569;
+        font-size: 10px;
+        font-weight: 800;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
+      }
+      .review-finding {
+        display: grid;
+        grid-template-columns: 18px minmax(0, 1fr);
+        gap: 9px;
+        padding: 10px 11px;
+        border: 1px solid #e2e8f0;
+        border-radius: 9px;
+        font-size: 12px;
+      }
+      .review-finding + .review-finding { margin-top: 8px; }
+      .review-finding-pass { color: #15803d; border-color: #bbf7d0; background: #f0fdf4; }
+      .review-finding-warning { color: #b45309; border-color: #fde68a; background: #fffbeb; }
+      .review-finding-fail { color: #b91c1c; border-color: #fecaca; background: #fef2f2; }
+      .review-finding-message { color: #334155; font-weight: 700; line-height: 1.4; }
+      .review-finding-suggestion { margin-top: 4px; color: #64748b; line-height: 1.45; }
+      .review-source {
+        display: inline-block;
+        margin-top: 5px;
+        color: #94a3b8;
+        font-size: 9px;
+        font-weight: 700;
+        text-transform: uppercase;
+      }
+      .review-empty-state {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 12px;
+        border-radius: 9px;
+        color: #166534;
+        background: #f0fdf4;
+        font-size: 12px;
+        font-weight: 700;
+      }
+      .review-muted { color: #94a3b8; font-size: 11px; }
+      .deploy-order-list,
+      .relationship-list,
+      .dependency-list,
+      .file-relationship-list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      .deploy-order-list { display: flex; flex-wrap: wrap; gap: 7px; }
+      .deploy-order-list li {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 8px;
+        border-radius: 7px;
+        background: #eef2ff;
+        color: #4338ca;
+        font-size: 10px;
+        font-weight: 700;
+      }
+      .deploy-order-list li span {
+        display: grid;
+        width: 17px;
+        height: 17px;
+        place-items: center;
+        border-radius: 5px;
+        color: #fff;
+        background: #6366f1;
+        font-size: 9px;
+      }
+      .relationship-list { display: flex; flex-direction: column; gap: 7px; }
+      .relationship-list li {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 6px;
+        color: #475569;
+        font-size: 11px;
+      }
+      .relationship-list li > span {
+        padding: 2px 5px;
+        border-radius: 5px;
+        background: #f1f5f9;
+        color: #64748b;
+        font-size: 9px;
+      }
+      .relationship-list li p { width: 100%; color: #94a3b8; }
       .btn-header-action {
         display: flex;
         align-items: center;
@@ -750,12 +845,12 @@
         box-shadow: 0 4px 14px -2px rgba(245,158,11,0.5);
       }
       .btn-refine-regen {
-        background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
+        background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
         color: #fff;
-        box-shadow: 0 2px 8px -2px rgba(99,102,241,0.4);
+        box-shadow: 0 2px 8px -2px rgba(249,115,22,0.4);
       }
       .btn-refine-regen:hover:not(:disabled) {
-        box-shadow: 0 4px 14px -2px rgba(99,102,241,0.5);
+        box-shadow: 0 4px 14px -2px rgba(249,115,22,0.5);
       }
 
       .results-action-bar {
@@ -777,12 +872,20 @@
         flex-grow: 1.45;
       }
       .btn-deploy-results {
-        background: linear-gradient(135deg, #f97316 0%, #ea580c 100%);
+        background: linear-gradient(135deg, #6366f1 0%, #4f46e5 100%);
         color: #fff;
-        box-shadow: 0 2px 8px -2px rgba(249,115,22,0.4);
+        box-shadow: 0 2px 8px -2px rgba(99,102,241,0.4);
       }
       .btn-deploy-results:hover:not(:disabled) {
-        box-shadow: 0 4px 14px -2px rgba(249,115,22,0.5);
+        box-shadow: 0 4px 14px -2px rgba(99,102,241,0.5);
+      }
+      .flutterflow-deploy-icon {
+        width: 18px;
+        height: 18px;
+        flex: 0 0 18px;
+        object-fit: contain;
+        filter: grayscale(1) invert(1) contrast(10);
+        mix-blend-mode: screen;
       }
 
       .results-split {
@@ -853,62 +956,486 @@
         color: #e2e8f0;
       }
       .panel-audit-wrap {
-        padding: 24px;
+        padding: 18px;
       }
-
-      .results-footer {
+      .file-review-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 15px;
+        border: 1px solid #e2e8f0;
+        border-left-width: 4px;
+        border-radius: 11px;
+        background: #f8fafc;
+      }
+      .file-review-pass { border-left-color: #22c55e; }
+      .file-review-warning { border-left-color: #f59e0b; }
+      .file-review-fail { border-left-color: #ef4444; }
+      .file-review-status {
         display: flex;
         align-items: center;
-        justify-content: space-between;
-        padding: 16px 24px;
-        border-top: 1px solid var(--border);
-        background: #fff;
-        flex-shrink: 0;
+        gap: 5px;
+        color: #64748b;
+        font-size: 9px;
+        font-weight: 800;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
       }
-      .results-footer-left {
+      .file-review-header h3 {
+        margin-top: 5px;
+        color: var(--navy);
+        font-size: 15px;
+        font-weight: 800;
+      }
+      .file-review-header p {
+        margin-top: 5px;
+        color: #64748b;
+        font-size: 11px;
+        line-height: 1.45;
+      }
+      .file-review-meta {
         display: flex;
-        gap: 10px;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 4px;
+        color: #64748b;
+        font-size: 9px;
+        font-weight: 700;
       }
-      .results-footer-right {
+      .file-review-meta span {
+        max-width: 220px;
+        overflow: hidden;
+        padding: 3px 6px;
+        border-radius: 5px;
+        background: #fff;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .file-review-section {
+        margin-top: 14px;
+        padding: 14px;
+        border: 1px solid #e2e8f0;
+        border-radius: 11px;
+        background: #fff;
+      }
+      .file-manual-section {
+        border-color: #fde68a;
+        background: #fffbeb;
+      }
+      .file-manual-section ol {
+        display: flex;
+        flex-direction: column;
+        gap: 9px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+      .file-detail-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
+      .dependency-list { display: flex; flex-direction: column; gap: 7px; }
+      .dependency-list li {
+        color: #475569;
+        font-size: 11px;
+      }
+      .dependency-list code,
+      .code-chip-list code {
+        display: inline-block;
+        padding: 4px 6px;
+        border: 1px solid #e2e8f0;
+        border-radius: 6px;
+        color: #4338ca;
+        background: #f8fafc;
+        font-family: "DM Mono", monospace;
+        font-size: 10px;
+      }
+      .dependency-list p { margin-top: 4px; color: #64748b; line-height: 1.4; }
+      .file-deploy-facts { display: flex; flex-direction: column; gap: 7px; }
+      .file-deploy-facts div {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        color: #64748b;
+        font-size: 10px;
+      }
+      .file-deploy-facts dt { font-weight: 700; }
+      .file-deploy-facts dd { color: #334155; text-align: right; }
+      .code-chip-list { display: flex; flex-wrap: wrap; gap: 6px; }
+      .file-relationship-list { display: flex; flex-direction: column; gap: 7px; }
+      .file-relationship-list li { color: #475569; font-size: 11px; }
+      .file-relationship-list li p { margin-top: 3px; color: #94a3b8; }
+      body.results-fullscreen .sidebar {
+        display: none;
+      }
+      body.results-fullscreen .main-content {
+        display: block;
+        width: 100vw;
+        height: 100dvh;
+        padding: 0;
+      }
+      body.results-fullscreen .main-stage {
+        inset: 0;
+        border-radius: 0;
+        box-shadow: none;
+      }
+      body.results-fullscreen.results-with-sidebar .sidebar {
+        display: flex;
+      }
+      body.results-fullscreen.results-with-sidebar .main-content {
+        width: auto;
+        height: 100vh;
+        padding: 36px;
+      }
+      body.results-fullscreen.results-with-sidebar .main-stage {
+        inset: 28px;
+        border-radius: 14px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 6px 24px rgba(0,0,0,0.05);
+      }
+      body.results-fullscreen .results-header {
+        padding: 14px 28px;
+      }
+      .results-header-left {
+        display: flex;
+        align-items: center;
+      }
+      body.results-fullscreen .bundle-strip {
+        padding: 10px 28px;
+      }
+      body.results-fullscreen .artifact-tab {
+        min-width: 0;
+        max-width: 260px;
+        padding: 8px 11px;
+        border-radius: 8px;
+      }
+      body.results-fullscreen .artifact-tab-status {
+        width: 22px;
+        height: 22px;
+        flex-basis: 22px;
+        border-radius: 6px;
+      }
+      body.results-fullscreen .artifact-tab-name { font-size: 12px; }
+      body.results-fullscreen .artifact-tab-meta { margin-top: 1px; font-size: 9px; }
+      .file-technical-details {
+        margin-top: 18px;
+        border-top: 1px solid var(--border);
+      }
+      .file-technical-details > summary {
+        padding: 14px 0;
+        color: #64748b;
+        cursor: pointer;
+        font-size: 11px;
+        font-weight: 700;
+      }
+      .file-technical-details .file-review-section:first-of-type { margin-top: 0; }
+
+      /* Results hierarchy: review first, files second. */
+      body.results-fullscreen .results-header {
+        min-height: 72px;
+        padding: 14px 36px;
+      }
+      body.results-fullscreen .results-header-left {
         display: flex;
         align-items: center;
         gap: 16px;
       }
-      .results-footer-right .feedback-label {
-        font-size: 12px;
-        color: var(--sublabel);
-        font-weight: 500;
+      body.results-fullscreen .results-header-left h2 {
+        color: #111827;
+        font-family: "Delight", "Outfit", sans-serif;
+        font-size: 28px;
+        font-weight: 650;
+        letter-spacing: -0.025em;
       }
-
-      .btn-footer {
+      body.results-fullscreen .results-summary-detail {
+        flex: 0 1 auto;
+        max-height: 340px;
+        padding: 26px 36px 24px;
+        overflow-y: auto;
+        border-bottom: 1px solid #e5e7eb;
+      }
+      .review-summary {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 184px;
+        gap: 48px;
+        width: 100%;
+        max-width: 1280px;
+        margin: 0 auto;
+      }
+      .review-summary-copy { min-width: 0; }
+      .results-file-count {
+        padding: 6px 9px;
+        border-radius: 6px;
+        color: #6b7280;
+        background: #f3f4f6;
+        font-size: 12px;
+        font-weight: 700;
+      }
+      .review-summary-text {
+        max-width: 900px;
+        margin-top: 0;
+        color: #374151;
+        font-size: 14px;
+        line-height: 1.65;
+        white-space: pre-line;
+      }
+      .review-score {
+        display: flex;
+        width: 100%;
+        min-height: 164px;
+        padding: 18px 16px;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        align-self: start;
+        border: 1px solid;
+        border-radius: 10px;
+        text-align: center;
+      }
+      .review-score-column {
+        width: 184px;
+        align-self: start;
+      }
+      .review-score-pass { color: #166534; border-color: #86efac; background: #f0fdf4; }
+      .review-score-warning { color: #9a3412; border-color: #fdba74; background: #fff7ed; }
+      .review-score-fail { color: #991b1b; border-color: #fca5a5; background: #fef2f2; }
+      .review-score-label {
+        font-size: 11px;
+        font-weight: 800;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+      .review-score strong {
+        margin-top: 3px;
+        font-family: "Delight", "Outfit", sans-serif;
+        font-size: 58px;
+        font-weight: 700;
+        line-height: 0.95;
+        letter-spacing: -0.05em;
+      }
+      .review-score-total {
+        margin-top: 5px;
+        font-size: 11px;
+        font-weight: 600;
+        opacity: 0.72;
+      }
+      .review-score-status {
+        margin-top: 12px;
+        font-size: 11px;
+        font-weight: 800;
+        text-transform: uppercase;
+      }
+      .summary-manual-callout {
+        margin-top: 18px;
+        padding: 13px 15px;
+        border: 1px solid #fed7aa;
+        border-radius: 8px;
+        background: #fff7ed;
+      }
+      .summary-manual-callout h3 {
         display: flex;
         align-items: center;
-        gap: 8px;
-        padding: 10px 20px;
-        border-radius: 10px;
-        border: none;
-        cursor: pointer;
+        gap: 7px;
+        color: #9a3412;
         font-size: 13px;
-        font-weight: 600;
-        font-family: "Delight", "DM Sans", sans-serif;
-        transition: all 0.2s ease;
+        font-weight: 750;
       }
-      .btn-footer:hover { transform: translateY(-1px); }
-      .btn-footer:active { transform: scale(0.97); }
-      .btn-footer:disabled { opacity: 0.5; cursor: not-allowed; transform: none; }
+      .summary-manual-callout h3 .review-status-icon {
+        width: 16px;
+        height: 16px;
+      }
+      .summary-manual-callout ul {
+        display: grid;
+        gap: 7px;
+        margin: 10px 0 0;
+        padding: 0 0 0 23px;
+        list-style: disc;
+      }
+      .summary-manual-callout li {
+        color: #7c2d12;
+        font-size: 14px;
+        line-height: 1.45;
+      }
+      .summary-manual-callout li strong { font-weight: 700; }
+      .summary-manual-callout li span { display: block; margin-top: 2px; color: #9a3412; }
+      .summary-findings {
+        display: grid;
+        gap: 7px;
+        margin: 14px 0 0;
+        padding: 0;
+        list-style: none;
+      }
+      .summary-findings li {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+        color: #374151;
+        font-size: 14px;
+        line-height: 1.45;
+      }
+      .summary-findings .review-status-icon { margin-top: 2px; }
+      .review-score-feedback {
+        width: 100%;
+        margin-top: 10px;
+        color: #6b7280;
+        font-size: 11px;
+        font-weight: 650;
+        text-align: center;
+      }
+      .review-score-feedback-controls {
+        display: flex;
+        justify-content: center;
+        gap: 7px;
+        margin-top: 7px;
+      }
+      .review-score-feedback .feedback-btn {
+        width: 30px;
+        height: 30px;
+        border-radius: 6px;
+        opacity: 1;
+      }
+      .review-score-feedback .feedback-btn svg { width: 14px; height: 14px; }
+      body.results-fullscreen .bundle-strip {
+        grid-template-columns: auto 1px minmax(0, 1fr);
+        align-items: center;
+        gap: 16px;
+        padding: 10px 36px;
+        background: #f9fafb;
+      }
+      body.results-fullscreen .bundle-strip.visible { display: grid; }
+      .results-summary-tab {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        min-height: 38px;
+        padding: 0 13px;
+        border: 1px solid #d1d5db;
+        border-radius: 7px;
+        color: #374151;
+        background: #fff;
+        cursor: pointer;
+        font: 750 13px "Delight", "DM Sans", sans-serif;
+      }
+      .results-summary-tab:hover { color: #111827; border-color: #9ca3af; }
+      .results-summary-tab.active {
+        color: #fff;
+        border-color: #111827;
+        background: #111827;
+      }
+      .results-summary-tab svg { width: 16px; height: 16px; }
+      .results-nav-divider {
+        width: 1px;
+        height: 34px;
+        background: #d1d5db;
+      }
+      body.results-fullscreen .artifact-tab {
+        min-width: 148px;
+        padding: 8px 10px;
+        border-color: #e5e7eb;
+        border-radius: 7px;
+      }
+      body.results-fullscreen .artifact-tab.active {
+        border-color: #111827;
+        background: #fff;
+        box-shadow: inset 0 0 0 1px #111827;
+      }
+      body.results-fullscreen .artifact-tab-name { font-size: 13px; font-weight: 700; }
+      body.results-fullscreen .artifact-tab-meta { font-size: 11px; }
+      .panel-code-wrap { position: relative; }
+      .code-copy-button {
+        position: absolute;
+        z-index: 2;
+        top: 12px;
+        right: 12px;
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 7px 10px;
+        border: 1px solid #4b5563;
+        border-radius: 6px;
+        color: #d1d5db;
+        background: #272936;
+        cursor: pointer;
+        font: 700 11px "Delight", "DM Sans", sans-serif;
+      }
+      .code-copy-button:hover { color: #fff; border-color: #6b7280; background: #333544; }
+      .code-copy-button.copied { color: #bbf7d0; border-color: #166534; background: #14532d; }
+      body.results-fullscreen .panel-code-wrap pre { padding-top: 56px; }
+      body.results-fullscreen .results-action-bar {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        margin-top: auto;
+        padding: 10px 36px;
+        background: #fff;
+      }
+      body.results-fullscreen .results-action-bar .btn-header-action {
+        width: 100%;
+        min-height: 44px;
+        justify-content: center;
+      }
+      body.results-fullscreen .file-review-header h3 { font-size: 16px; }
+      body.results-fullscreen .file-review-header p,
+      body.results-fullscreen .review-finding,
+      body.results-fullscreen .dependency-list li,
+      body.results-fullscreen .file-relationship-list li {
+        font-size: 14px;
+      }
+      .results-view button:focus-visible,
+      .results-view summary:focus-visible {
+        outline: 2px solid #f97316;
+        outline-offset: 2px;
+      }
 
-      .btn-copy-footer {
-        background: #f1f5f9;
-        color: var(--navy);
-        border: 1px solid var(--border);
+      @media (max-width: 760px) {
+        .review-summary { grid-template-columns: 1fr; gap: 20px; }
+        .review-score-column { width: 100%; }
+        .review-score { width: 100%; min-height: 130px; }
+        body.results-fullscreen .results-summary-detail { max-height: 430px; padding: 22px 18px; }
+        body.results-fullscreen .bundle-strip {
+          grid-template-columns: auto 1px minmax(0, 1fr);
+          padding: 10px 18px;
+        }
+        body.results-fullscreen .artifact-tabs { grid-column: 1 / -1; width: 100%; }
+        body.results-fullscreen .results-header { padding: 12px 18px; }
+        body.results-fullscreen .results-header-left h2 { font-size: 22px; }
+        body.results-fullscreen .results-action-bar { grid-template-columns: 1fr; }
       }
-      .btn-copy-footer:hover:not(:disabled) {
-        background: #e2e8f0;
+      @media (prefers-reduced-motion: reduce) {
+        .results-view *,
+        .results-view *::before,
+        .results-view *::after {
+          scroll-behavior: auto !important;
+          transition-duration: 0.01ms !important;
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+        }
       }
-      .btn-copy-footer.copied {
-        background: #065f46;
-        color: #a7f3d0;
-        border-color: #065f46;
+      .hidden {
+        display: none !important;
+      }
+
+      @media (max-width: 980px) {
+        .results-split { grid-template-columns: minmax(0, 1fr); overflow-y: auto; }
+        .results-panel { min-height: 420px; }
+        .results-panel + .results-panel {
+          border-top: 1px solid var(--border);
+          border-left: none;
+        }
+      }
+
+      @media (max-width: 640px) {
+        .results-header,
+        .bundle-strip,
+        .results-summary-detail,
+        .results-action-bar {
+          padding-left: 14px;
+          padding-right: 14px;
+        }
+        .artifact-tab { min-width: 150px; }
+        .file-detail-grid { grid-template-columns: 1fr; }
+        .file-review-header { flex-direction: column; }
+        .file-review-meta { align-items: flex-start; }
       }
 
       .feedback-btn {
@@ -2075,30 +2602,26 @@
             <div id="results-view" class="results-view">
               <div class="results-header">
                 <div class="results-header-left">
-                  <h2>Generation Results</h2>
-                  <p>Review the generated code and audit report below</p>
+                  <h2 id="results-title">Generation Results</h2>
                 </div>
+                <span id="results-file-count" class="results-file-count">0 files</span>
               </div>
 
               <div id="bundle-strip" class="bundle-strip">
-                <div class="bundle-summary">
-                  <div class="bundle-stat">
-                    <span id="bundle-artifact-count" class="bundle-stat-value">1</span>
-                    <span class="bundle-stat-label">Artifacts</span>
-                  </div>
-                  <div class="bundle-stat">
-                    <span id="bundle-deployable-count" class="bundle-stat-value">1</span>
-                    <span class="bundle-stat-label">Ready</span>
-                  </div>
-                  <div class="bundle-stat">
-                    <span id="bundle-warning-count" class="bundle-stat-value">0</span>
-                    <span class="bundle-stat-label">Warnings</span>
-                  </div>
-                </div>
+                <button id="results-summary-tab" class="results-summary-tab" type="button" onclick="selectResultsSummary()">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M9 5h6M9 9h6M9 13h4"/>
+                    <path d="M7 3h10a2 2 0 0 1 2 2v14H5V5a2 2 0 0 1 2-2Z"/>
+                  </svg>
+                  <span>Summary</span>
+                </button>
+                <div class="results-nav-divider" aria-hidden="true"></div>
                 <div id="artifact-tabs" class="artifact-tabs"></div>
               </div>
 
-              <div class="results-split">
+              <div id="results-summary-detail" class="results-summary-detail"></div>
+
+              <div id="artifact-results-split" class="results-split hidden">
                 <!-- Left panel: Generated Code -->
                 <div class="results-panel">
                   <div class="panel-header">
@@ -2109,6 +2632,10 @@
                   </div>
                   <div class="panel-body">
                     <div class="panel-code-wrap">
+                      <button id="btn-copy-results" class="code-copy-button" onclick="copyResultsCode()">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                        <span>Copy</span>
+                      </button>
                       <pre id="results-code-output" class="code-font"></pre>
                     </div>
                   </div>
@@ -2120,7 +2647,7 @@
                     <div class="panel-header-icon">
                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
                     </div>
-                    <span class="panel-header-label">Live Audit Report</span>
+                    <span class="panel-header-label">File Review</span>
                   </div>
                   <div class="panel-body">
                     <div class="panel-audit-wrap" id="results-audit-output"></div>
@@ -2130,9 +2657,7 @@
 
               <div class="results-action-bar" aria-label="Generation actions">
                 <button id="btn-deploy-to-ff" class="btn-header-action btn-deploy-results hidden" onclick="initiateCommitToFlutterFlow()">
-                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
-                  </svg>
+                  <img class="flutterflow-deploy-icon" src="https://flutterflow.io/favicon.ico" alt="" />
                   Deploy to FlutterFlow
                 </button>
                 <button id="btn-error-regen-header" class="btn-header-action btn-error-regen" onclick="showErrorInputPanel()">
@@ -2143,24 +2668,6 @@
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
                   Refine &amp; Regenerate
                 </button>
-              </div>
-
-              <div class="results-footer">
-                <div class="results-footer-left">
-                  <button id="btn-copy-results" class="btn-footer btn-copy-footer" onclick="copyResultsCode()">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
-                    <span>Copy to Clipboard</span>
-                  </button>
-                </div>
-                <div class="results-footer-right">
-                  <span class="feedback-label">Was this generation accurate?</span>
-                  <button class="feedback-btn" id="btn-feedback-up" onclick="submitResultsFeedback('up')" title="Good generation">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 9V5a3 3 0 00-3-3l-4 9v11h11.28a2 2 0 002-1.7l1.38-9a2 2 0 00-2-2.3H14z"/></svg>
-                  </button>
-                  <button class="feedback-btn" id="btn-feedback-down" onclick="submitResultsFeedback('down')" title="Needs improvement">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 15v4a3 3 0 003 3l4-9V2H5.72a2 2 0 00-2 1.7l-1.38 9a2 2 0 002 2.3H10z"/></svg>
-                  </button>
-                </div>
               </div>
             </div>
 

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="brand-background" x1="2" y1="2" x2="22" y2="22" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0f172a"/>
+      <stop offset="1" stop-color="#1e293b"/>
+    </linearGradient>
+  </defs>
+  <rect width="24" height="24" rx="7" fill="url(#brand-background)"/>
+  <g transform="translate(4 4) scale(.6667)">
+    <path d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
+          fill="none"
+          stroke="#fff"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          vector-effect="non-scaling-stroke"/>
+  </g>
+</svg>

--- a/src/artifactBundle.js
+++ b/src/artifactBundle.js
@@ -51,6 +51,7 @@ export function normalizeArtifact(rawArtifact = {}, index = 0) {
     code: artifact.code || artifact.content || "",
     dependencies: normalizeDependencies(artifact.dependencies),
     imports: Array.isArray(artifact.imports) ? artifact.imports : [],
+    publicApi: Array.isArray(artifact.publicApi) ? artifact.publicApi : [],
     relationships: normalizeRelationships(artifact.relationships),
     deployStatus: artifact.deployStatus || "pending",
     review: artifact.review || null,
@@ -75,6 +76,7 @@ export function normalizeDependencies(rawDependencies) {
           name,
           version: dep.version || null,
           inferred: Boolean(dep.inferred),
+          ...(dep.reason ? { reason: dep.reason } : {}),
         };
       })
       .filter(Boolean);
@@ -161,6 +163,7 @@ export function normalizeArtifactBundle(input, options = {}) {
     }));
 
   return {
+    schemaVersion: bundleLike.schemaVersion || options.schemaVersion || null,
     id: bundleLike.id || options.id || "bundle-current",
     title: bundleLike.title || bundleLike.name || options.title || "Generated artifact bundle",
     description: bundleLike.description || options.description || "",

--- a/src/reviewPresentation.js
+++ b/src/reviewPresentation.js
@@ -1,0 +1,343 @@
+import { parseJsonLike } from "./artifactBundle.js";
+
+const STATUS_RANK = { pass: 0, warning: 1, fail: 2 };
+const MANUAL_STEP_KEYS = [
+  "manualSteps",
+  "manualActions",
+  "requiredActions",
+  "flutterFlowSteps",
+  "flutterFlowActions",
+  "requiredUserActions",
+  "requiredFlutterFlowActions",
+  "flutterFlowSetup",
+  "userActions",
+  "nextSteps",
+];
+
+function toObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+}
+
+function firstText(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+    if (Array.isArray(value) && value.length > 0) {
+      const text = value.filter((item) => typeof item === "string").join("\n");
+      if (text) return text;
+    }
+  }
+  return "";
+}
+
+function asArray(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function parseScore(value) {
+  const direct = Number(toObject(value).value ?? value);
+  if (Number.isFinite(direct)) return direct;
+  const match = String(value || "").match(/\bscore\b[^\d]{0,12}(\d{1,3})(?:\s*\/\s*100)?/i);
+  return match ? Number(match[1]) : null;
+}
+
+function slugify(value) {
+  return String(value || "")
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function normalizeReviewStatus(value) {
+  const status = String(value || "").toLowerCase();
+  if (/(fail|error|critical|block|reject|invalid)/.test(status)) return "fail";
+  if (/(warn|attention|manual|partial|incomplete|concern)/.test(status)) return "warning";
+  if (/(pass|success|ready|approve|valid|clean)/.test(status)) return "pass";
+  return null;
+}
+
+function worstStatus(...statuses) {
+  return statuses
+    .filter(Boolean)
+    .reduce((worst, status) => (
+      STATUS_RANK[status] > STATUS_RANK[worst] ? status : worst
+    ), "pass");
+}
+
+function normalizeFinding(rawFinding, defaultSeverity = "warning", source = "review") {
+  if (typeof rawFinding === "string") {
+    return { severity: defaultSeverity, message: rawFinding, suggestion: "", source };
+  }
+
+  const finding = toObject(rawFinding);
+  const message = firstText(
+    finding.message,
+    finding.title,
+    finding.issue,
+    finding.description,
+    finding.summary,
+  );
+  if (!message) return null;
+
+  return {
+    severity: normalizeReviewStatus(finding.severity || finding.status || finding.level)
+      || defaultSeverity,
+    message,
+    suggestion: firstText(
+      finding.suggestion,
+      finding.fix,
+      finding.recommendation,
+      finding.action,
+    ),
+    source: finding.source || source,
+  };
+}
+
+function collectFindings(source, provenance = "review") {
+  const object = toObject(source);
+  const groups = [
+    ["findings", "warning"],
+    ["issues", "warning"],
+    ["criticalIssues", "fail"],
+    ["errors", "fail"],
+    ["warnings", "warning"],
+    ["recommendations", "warning"],
+    ["requiredFixes", "fail"],
+    ["suggestions", "warning"],
+  ];
+
+  return groups.flatMap(([key, severity]) => (
+    asArray(object[key])
+      .map((finding) => normalizeFinding(finding, severity, provenance))
+      .filter(Boolean)
+  ));
+}
+
+function normalizeManualStep(rawStep, index, artifactId = null) {
+  if (typeof rawStep === "string") {
+    return {
+      id: `${artifactId || "bundle"}-manual-${index + 1}`,
+      title: rawStep,
+      detail: "",
+      location: "",
+      timing: "unspecified",
+      artifactId,
+      source: "Code Review",
+    };
+  }
+
+  const step = toObject(rawStep);
+  const title = firstText(
+    step.title,
+    step.action,
+    step.step,
+    step.message,
+    step.name,
+    step.description,
+  );
+  if (!title) return null;
+
+  return {
+    id: step.id || `${artifactId || "bundle"}-manual-${index + 1}`,
+    title,
+    detail: firstText(step.detail, step.instructions, step.description),
+    location: firstText(step.location, step.flutterFlowPath, step.path),
+    timing: firstText(step.timing, step.phase) || "unspecified",
+    artifactId,
+    source: firstText(step.source) || "Code Review",
+  };
+}
+
+function collectManualSteps(source, artifactId = null) {
+  const object = toObject(source);
+  return MANUAL_STEP_KEYS.flatMap((key) => asArray(object[key]))
+    .map((step, index) => normalizeManualStep(step, index, artifactId))
+    .filter(Boolean);
+}
+
+function unwrapReviewPayload(reviewResult) {
+  let value = typeof reviewResult === "string" ? parseJsonLike(reviewResult) : reviewResult;
+  if (!value && typeof reviewResult === "string") {
+    return { rawText: reviewResult, root: {} };
+  }
+
+  const envelope = toObject(value);
+  if (typeof envelope.content === "string") {
+    value = parseJsonLike(envelope.content) || value;
+  }
+
+  const root = toObject(value);
+  const nested = toObject(
+    root.bundleReview
+      || root.reviewResult
+      || root.codeReview
+      || root.result,
+  );
+  return { rawText: "", root: Object.keys(nested).length ? nested : root };
+}
+
+function findArtifactReview(reviewArtifacts, artifact) {
+  const candidates = [
+    artifact.id,
+    artifact.fileName,
+    artifact.artifactName,
+  ].map(slugify);
+
+  return reviewArtifacts.find((reviewArtifact) => {
+    const review = toObject(reviewArtifact);
+    return [review.id, review.fileName, review.artifactName, review.name]
+      .map(slugify)
+      .some((candidate) => candidate && candidates.includes(candidate));
+  }) || null;
+}
+
+function getPathHint(bundle, artifact) {
+  const hints = asArray(bundle?.metadata?.compatibility?.deployHints);
+  const match = hints.find((hint) => (
+    slugify(hint?.artifactId) === slugify(artifact.id)
+      || slugify(hint?.fileName) === slugify(artifact.fileName)
+  ));
+  return match?.pathHint || "";
+}
+
+function getArtifactRelationships(bundle, artifact) {
+  return asArray(bundle?.relationships).filter((relationship) => (
+    slugify(relationship?.from) === slugify(artifact.id)
+      || slugify(relationship?.to) === slugify(artifact.id)
+  ));
+}
+
+function getCompatibilityFindings(bundle, artifact) {
+  return asArray(bundle?.metadata?.compatibility?.findings)
+    .filter((finding) => (
+      !finding?.artifactId || slugify(finding.artifactId) === slugify(artifact.id)
+    ))
+    .map((finding) => normalizeFinding(finding, "warning", "Compatibility check"))
+    .filter(Boolean);
+}
+
+function buildArtifactPresentation(bundle, reviewArtifacts, artifact, index) {
+  const rawArtifactReview = findArtifactReview(reviewArtifacts, artifact);
+  const review = toObject(rawArtifactReview?.review || rawArtifactReview || artifact.review);
+  const hasStructuredReview = Object.keys(review).length > 0;
+  const findings = [
+    ...collectFindings(review),
+    ...getCompatibilityFindings(bundle, artifact),
+  ];
+  const manualSteps = collectManualSteps(review, artifact.id);
+  const explicitStatus = normalizeReviewStatus(
+    review.status || review.verdict || review.outcome || review.result,
+  );
+  const findingStatus = findings.length
+    ? worstStatus(...findings.map((finding) => finding.severity))
+    : null;
+  const status = worstStatus(
+    explicitStatus,
+    findingStatus,
+    hasStructuredReview ? null : "warning",
+  );
+
+  return {
+    ...artifact,
+    index,
+    status,
+    statusReason: hasStructuredReview
+      ? firstText(review.summary, review.overview, review.assessment, review.conclusion)
+        || (findings.length ? `${findings.length} review finding${findings.length === 1 ? "" : "s"}` : "No file-level findings")
+      : "No file-level verdict was returned",
+    reviewComplete: hasStructuredReview,
+    findings,
+    manualSteps,
+    pathHint: getPathHint(bundle, artifact),
+    relationships: getArtifactRelationships(bundle, artifact),
+  };
+}
+
+export function buildReviewPresentation({ bundle, reviewResult }) {
+  const safeBundle = toObject(bundle);
+  const artifacts = asArray(safeBundle.artifacts);
+  const { root, rawText } = unwrapReviewPayload(reviewResult);
+  const overallReview = toObject(
+    root.overallReview
+      || root.overall
+      || root.bundleSummary
+      || root.summaryReview
+      || root.review,
+  );
+  const reviewArtifacts = asArray(root.artifacts || root.files || root.reviews);
+  const artifactPresentations = artifacts.map((artifact, index) => (
+    buildArtifactPresentation(safeBundle, reviewArtifacts, artifact, index)
+  ));
+
+  const rootFindings = collectFindings(root);
+  const overallFindings = collectFindings(overallReview);
+  const findings = [...overallFindings, ...rootFindings];
+  const manualSteps = [
+    ...collectManualSteps(overallReview),
+    ...collectManualSteps(root),
+    ...artifactPresentations.flatMap((artifact) => artifact.manualSteps),
+  ].filter((step, index, all) => (
+    all.findIndex((candidate) => (
+      candidate.title === step.title && candidate.artifactId === step.artifactId
+    )) === index
+  ));
+  const explicitStatus = normalizeReviewStatus(
+    overallReview.status
+      || overallReview.verdict
+      || overallReview.overallStatus
+      || root.status
+      || root.verdict
+      || root.overallStatus
+      || root.outcome,
+  );
+  const status = worstStatus(
+    explicitStatus,
+    ...findings.map((finding) => finding.severity),
+    ...artifactPresentations.map((artifact) => artifact.status),
+  );
+  const rawScore = overallReview.score ?? root.score ?? root.overallScore ?? rawText;
+  const scoreValue = parseScore(rawScore);
+  const summary = firstText(
+    overallReview.headline,
+    overallReview.summary,
+    overallReview.executiveSummary,
+    overallReview.overview,
+    overallReview.assessment,
+    overallReview.conclusion,
+    root.overallSummary,
+    root.headline,
+    root.summary,
+    root.executiveSummary,
+    root.overview,
+    root.assessment,
+    root.conclusion,
+    rawText,
+    safeBundle.description,
+  ) || "Code Review completed without an overarching written summary.";
+  const counts = artifactPresentations.reduce((result, artifact) => {
+    result[artifact.status] += 1;
+    return result;
+  }, { pass: 0, warning: 0, fail: 0 });
+
+  return {
+    title: safeBundle.title || "Generated artifact bundle",
+    description: safeBundle.description || "",
+    status,
+    score: scoreValue,
+    summary,
+    findings,
+    manualSteps,
+    artifacts: artifactPresentations,
+    counts,
+    reviewCoverage: {
+      reviewed: artifactPresentations.filter((artifact) => artifact.reviewComplete).length,
+      total: artifactPresentations.length,
+    },
+    deployOrder: asArray(safeBundle.deployOrder),
+    relationships: asArray(safeBundle.relationships),
+    warnings: asArray(safeBundle.warnings),
+    compatibility: toObject(safeBundle.metadata?.compatibility),
+  };
+}

--- a/src/reviewPresentation.test.js
+++ b/src/reviewPresentation.test.js
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildReviewPresentation, normalizeReviewStatus } from "./reviewPresentation.js";
+
+const bundle = {
+  title: "NFC bundle",
+  description: "Connect NFC scans to a webhook.",
+  artifacts: [
+    {
+      id: "format-payload",
+      artifactName: "formatPayload",
+      artifactType: "CustomFunction",
+      fileName: "format_payload.dart",
+      code: "String formatPayload() => '';",
+      dependencies: [],
+      imports: ["dart:convert"],
+    },
+    {
+      id: "execute-webhook",
+      artifactName: "executeWebhook",
+      artifactType: "CustomAction",
+      fileName: "execute_webhook.dart",
+      code: "Future<bool> executeWebhook() async => true;",
+      dependencies: [{ name: "http", version: "^1.2.0" }],
+      imports: ["package:http/http.dart"],
+    },
+  ],
+  relationships: [
+    { from: "execute-webhook", to: "format-payload", type: "calls" },
+  ],
+  deployOrder: ["format-payload", "execute-webhook"],
+  warnings: [],
+  metadata: {
+    compatibility: {
+      valid: true,
+      findings: [],
+      deployHints: [
+        { artifactId: "execute-webhook", pathHint: "actions/" },
+      ],
+    },
+  },
+};
+
+test("normalizes common review verdict vocabulary", () => {
+  assert.equal(normalizeReviewStatus("approved"), "pass");
+  assert.equal(normalizeReviewStatus("needs attention"), "warning");
+  assert.equal(normalizeReviewStatus("blocked"), "fail");
+  assert.equal(normalizeReviewStatus("unknown"), null);
+});
+
+test("builds an overarching summary and status-bearing file presentations", () => {
+  const presentation = buildReviewPresentation({
+    bundle,
+    reviewResult: JSON.stringify({
+      overallReview: {
+        status: "warning",
+        score: 88,
+        summary: "Safe to deploy after one FlutterFlow setup step.",
+        manualActions: [
+          {
+            title: "Confirm the http dependency",
+            location: "Settings > Project Dependencies",
+          },
+        ],
+      },
+      artifacts: [
+        {
+          id: "format_payload",
+          review: { status: "pass", findings: [] },
+        },
+        {
+          fileName: "execute_webhook.dart",
+          review: {
+            status: "warn",
+            findings: [
+              { severity: "warning", message: "Confirm endpoint authentication." },
+            ],
+          },
+        },
+      ],
+    }),
+  });
+
+  assert.equal(presentation.status, "warning");
+  assert.equal(presentation.score, 88);
+  assert.equal(presentation.summary, "Safe to deploy after one FlutterFlow setup step.");
+  assert.deepEqual(presentation.counts, { pass: 1, warning: 1, fail: 0 });
+  assert.equal(presentation.manualSteps[0].title, "Confirm the http dependency");
+  assert.equal(presentation.artifacts[1].pathHint, "actions/");
+  assert.equal(presentation.artifacts[1].relationships.length, 1);
+});
+
+test("treats missing file review evidence as warning rather than pass", () => {
+  const presentation = buildReviewPresentation({
+    bundle,
+    reviewResult: {
+      status: "pass",
+      summary: "Bundle compatibility passed.",
+      artifacts: [],
+    },
+  });
+
+  assert.equal(presentation.status, "warning");
+  assert.equal(presentation.reviewCoverage.reviewed, 0);
+  assert.equal(presentation.counts.warning, 2);
+  assert.match(presentation.artifacts[0].statusReason, /No file-level verdict/);
+});
+
+test("unwraps a message content envelope and preserves explicit manual steps", () => {
+  const presentation = buildReviewPresentation({
+    bundle,
+    reviewResult: {
+      role: "assistant",
+      content: JSON.stringify({
+        overallSummary: "One blocking issue.",
+        status: "fail",
+        flutterFlowSteps: ["Create the required App State variable."],
+        artifacts: [
+          {
+            id: "execute_webhook",
+            review: {
+              status: "fail",
+              criticalIssues: ["Missing callback wiring."],
+            },
+          },
+        ],
+      }),
+    },
+  });
+
+  assert.equal(presentation.status, "fail");
+  assert.equal(presentation.manualSteps.length, 1);
+  assert.equal(presentation.manualSteps[0].source, "Code Review");
+  assert.equal(presentation.artifacts[1].findings[0].severity, "fail");
+});
+
+test("extracts a prominent score from legacy markdown reviews", () => {
+  const presentation = buildReviewPresentation({
+    bundle,
+    reviewResult: "# Code Review\n\nScore: 74/100\n\nReview completed with warnings.",
+  });
+
+  assert.equal(presentation.score, 74);
+});


### PR DESCRIPTION
## Summary
- make the Code Review summary the primary Results view with a prominent score and explicit FlutterFlow follow-up
- add clearly separated Summary and per-file status tabs with pass, warning, and fail states
- restore the full-width bottom action bar, branded FlutterFlow deploy action, full-screen results layout, and matching favicon
- normalize partial Code Review payloads while preserving file metadata, dependencies, imports, public APIs, relationships, and manual steps

## Verification
- npm test (74 passed)
- npm run build
- git diff --check
- browser-verified summary/file navigation, full-width layout, fixed toolbar, bottom action alignment, favicon, and action colors