### PR TITLE
Fix unscored reviews and sidebar favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FlutterFlow Custom Code Connect</title>
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="/favicon-brand-v2.svg" type="image/svg+xml" />
     <meta name="description" content="Generate FlutterFlow-ready custom functions, actions, widgets, and code files that actually compile." />
     <link rel="canonical" href="https://customcode.connectio.com.au/" />
     <meta property="og:type" content="website" />

--- a/public/favicon-brand-v2.svg
+++ b/public/favicon-brand-v2.svg
@@ -6,12 +6,11 @@
     </linearGradient>
   </defs>
   <rect width="40" height="40" rx="12" fill="url(#brand-background)"/>
-  <g transform="translate(10 10) scale(.833333)">
+  <svg x="10" y="10" width="20" height="20" viewBox="0 0 24 24" fill="none">
     <path d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
-          fill="none"
           stroke="#fff"
           stroke-width="1.8"
           stroke-linecap="round"
           stroke-linejoin="round"/>
-  </g>
+  </svg>
 </svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,18 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
   <defs>
-    <linearGradient id="brand-background" x1="2" y1="2" x2="22" y2="22" gradientUnits="userSpaceOnUse">
+    <linearGradient id="brand-background" x1="0" y1="0" x2="40" y2="40" gradientUnits="userSpaceOnUse">
       <stop stop-color="#0f172a"/>
       <stop offset="1" stop-color="#1e293b"/>
     </linearGradient>
   </defs>
-  <rect width="24" height="24" rx="7" fill="url(#brand-background)"/>
-  <g transform="translate(4 4) scale(.6667)">
+  <rect width="40" height="40" rx="12" fill="url(#brand-background)"/>
+  <g transform="translate(10 10) scale(.833333)">
     <path d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
           fill="none"
           stroke="#fff"
           stroke-width="1.8"
           stroke-linecap="round"
-          stroke-linejoin="round"
-          vector-effect="non-scaling-stroke"/>
+          stroke-linejoin="round"/>
   </g>
 </svg>

--- a/src/reviewPresentation.js
+++ b/src/reviewPresentation.js
@@ -35,7 +35,15 @@ function asArray(value) {
 }
 
 function parseScore(value) {
-  const direct = Number(toObject(value).value ?? value);
+  const scoreValue = toObject(value).value ?? value;
+  if (
+    scoreValue == null
+    || (typeof scoreValue === "string" && scoreValue.trim() === "")
+  ) {
+    return null;
+  }
+
+  const direct = Number(scoreValue);
   if (Number.isFinite(direct)) return direct;
   const match = String(value || "").match(/\bscore\b[^\d]{0,12}(\d{1,3})(?:\s*\/\s*100)?/i);
   return match ? Number(match[1]) : null;

--- a/src/reviewPresentation.test.js
+++ b/src/reviewPresentation.test.js
@@ -142,3 +142,16 @@ test("extracts a prominent score from legacy markdown reviews", () => {
 
   assert.equal(presentation.score, 74);
 });
+
+test("leaves structured reviews without score fields unscored", () => {
+  const presentation = buildReviewPresentation({
+    bundle,
+    reviewResult: {
+      status: "warning",
+      summary: "Review completed without a numeric score.",
+      artifacts: [],
+    },
+  });
+
+  assert.equal(presentation.score, null);
+});


### PR DESCRIPTION
## Summary
- keep structured Code Review payloads without score fields in the intended Not scored state instead of coercing them to 0 / High risk
- add regression coverage for missing scores
- replace the cached favicon URL with an exact copy of the rendered sidebar icon dimensions, path, stroke, radius, and colors

## Verification
- npm test (75 passed)
- npm run build
- git diff --check
- production HTML, JavaScript, and favicon hashes match the local build