### PR TITLE
Fix mobile Results layout and review fallbacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1429,6 +1429,12 @@
         body.results-fullscreen .results-header-left h2 { font-size: 22px; }
         body.results-fullscreen .results-action-bar { grid-template-columns: 1fr; }
       }
+      @media (max-width: 768px) {
+        body.results-fullscreen .sidebar,
+        body.results-fullscreen.results-with-sidebar .sidebar {
+          display: none;
+        }
+      }
       @media (prefers-reduced-motion: reduce) {
         .results-view *,
         .results-view *::before,

--- a/src/resultsLayout.test.js
+++ b/src/resultsLayout.test.js
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const html = readFileSync(new URL("../index.html", import.meta.url), "utf8");
+
+test("hides the prompt sidebar above mobile Results", () => {
+  assert.match(
+    html,
+    /@media \(max-width: 768px\)[\s\S]*?body\.results-fullscreen \.sidebar,[\s\S]*?body\.results-fullscreen\.results-with-sidebar \.sidebar \{\s*display: none;/,
+  );
+});

--- a/src/reviewPresentation.js
+++ b/src/reviewPresentation.js
@@ -262,14 +262,16 @@ export function buildReviewPresentation({ bundle, reviewResult }) {
   const safeBundle = toObject(bundle);
   const artifacts = asArray(safeBundle.artifacts);
   const { root, rawText } = unwrapReviewPayload(reviewResult);
-  const overallReview = toObject(
-    root.bundleReview
-      || root.overallReview
-      || root.overall
-      || root.bundleSummary
-      || root.summaryReview
-      || root.review,
-  );
+  const overallReview = [
+    root.bundleReview,
+    root.overallReview,
+    root.overall,
+    root.bundleSummary,
+    root.summaryReview,
+    root.review,
+  ]
+    .map(toObject)
+    .find((candidate) => Object.keys(candidate).length) || {};
   const reviewArtifacts = asArray(root.artifacts || root.files || root.reviews);
   const artifactPresentations = artifacts.map((artifact, index) => (
     buildArtifactPresentation(safeBundle, reviewArtifacts, artifact, index)

--- a/src/reviewPresentation.test.js
+++ b/src/reviewPresentation.test.js
@@ -211,3 +211,30 @@ test("preserves top-level artifact reviews alongside bundleReview", () => {
   assert.equal(presentation.reviewCoverage.reviewed, 2);
   assert.equal(presentation.artifacts[0].findings[0].severity, "pass");
 });
+
+test("falls back from malformed bundleReview to a valid overallReview", () => {
+  for (const bundleReview of [{}, "not a review object"]) {
+    const presentation = buildReviewPresentation({
+      bundle,
+      reviewResult: {
+        bundleReview,
+        overallReview: {
+          status: "pass",
+          score: 94,
+          summary: "The valid overall review was preserved.",
+          findings: [
+            {
+              severity: "info",
+              message: "The bundle structure is valid.",
+            },
+          ],
+        },
+        artifacts: [],
+      },
+    });
+
+    assert.equal(presentation.score, 94);
+    assert.equal(presentation.summary, "The valid overall review was preserved.");
+    assert.equal(presentation.findings[0].message, "The bundle structure is valid.");
+  }
+});


### PR DESCRIPTION
## Summary
- hide the full-height prompting sidebar when Results is active at mobile widths so the review starts at the top
- ignore empty or malformed `bundleReview` values when a valid `overallReview` is available
- add regression coverage for both behaviors

## Verification
- `npm test` (78 passed)
- `npm run build`
- `git diff --check`