### PR TITLE
fix: surface commit parse failures + structured pipeline error-step detection (#13)

### DIFF
--- a/app.js
+++ b/app.js
@@ -33,6 +33,7 @@ import {
   validateProjectPubspec,
 } from "./src/pubspecSync.js";
 import { escapeAttr, escapeHtml, escapeHtmlText } from "./src/htmlEscape.js";
+import { resolvePipelineErrorStep } from "./src/pipelineErrors.js";
 import {
   extractCodeFromMarkdown,
   highlightCode,
@@ -2816,7 +2817,9 @@ async function executeCommit(code, options = {}) {
           const parsed = JSON.parse(match[0]);
           errorMap = new Map(Object.entries(parsed));
         }
-      } catch (e) {}
+      } catch (e) {
+        console.warn("Failed to parse error map from commit response:", e);
+      }
     }
 
     return {
@@ -3540,16 +3543,7 @@ async function runThinkingPipeline() {
       generator: 2,
       review: 3,
     };
-    let errorStep = modelArmorSteps[error.pipelineStep] || 1;
-    if (!error.pipelineStep && (
-      error.message.includes("Claude") ||
-      error.message.includes("OpenAI") ||
-      error.message.includes("Code Generator")
-    )) {
-      errorStep = 2;
-    } else if (!error.pipelineStep && error.message.includes("Code Review")) {
-      errorStep = 3;
-    }
+    const errorStep = resolvePipelineErrorStep(error, modelArmorSteps);
 
     selectWorkflowStep(errorStep);
     const resultDiv = document.getElementById(`step${errorStep}-result`);

--- a/src/pipelineErrors.js
+++ b/src/pipelineErrors.js
@@ -1,0 +1,30 @@
+/**
+ * Resolves which pipeline step (1 = Architect, 2 = Generator, 3 = Review) an
+ * error belongs to, so the UI can highlight the right step.
+ *
+ * The authoritative signal is a structured `error.pipelineStep` (a step label
+ * such as "architect" | "generator" | "review"), set on model-armor errors by
+ * `createModelArmorError`. We map that through `stepMap` first.
+ *
+ * When no structured step is present (e.g. plain network/provider errors
+ * wrapped by the `run*` helpers), we fall back to the step-name prefixes that
+ * app.js itself stamps onto those errors ("Prompt Architect failed:",
+ * "Code Generator failed:", "Code Review failed:"). Matching only our own
+ * reliable markers avoids the fragility of substring-matching raw provider
+ * names (a Gemini error quoting "Claude" would otherwise be misattributed).
+ *
+ * @param {Error} error
+ * @param {Record<string, number>} stepMap - label -> step index
+ * @returns {number} 1 | 2 | 3 (defaults to 1)
+ */
+export function resolvePipelineErrorStep(error, stepMap = {}) {
+  const pipelineStep = error?.pipelineStep;
+  if (pipelineStep != null && stepMap[pipelineStep] != null) {
+    return stepMap[pipelineStep];
+  }
+
+  const message = error?.message || "";
+  if (message.includes("Code Generator")) return 2;
+  if (message.includes("Code Review")) return 3;
+  return 1;
+}

--- a/src/pipelineErrors.test.js
+++ b/src/pipelineErrors.test.js
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolvePipelineErrorStep } from "./pipelineErrors.js";
+
+const STEP_MAP = { architect: 1, generator: 2, review: 3 };
+
+test("uses the structured pipelineStep when present", () => {
+  const error = new Error("anything");
+  error.pipelineStep = "review";
+  assert.equal(resolvePipelineErrorStep(error, STEP_MAP), 3);
+});
+
+test("identifies a generator error from app.js' own prefix", () => {
+  const error = new Error("Code Generator failed: primary (x): boom");
+  assert.equal(resolvePipelineErrorStep(error, STEP_MAP), 2);
+});
+
+test("identifies a review error from app.js' own prefix", () => {
+  const error = new Error("Code Review failed: boom");
+  assert.equal(resolvePipelineErrorStep(error, STEP_MAP), 3);
+});
+
+test("defaults an unknown error to step 1 (Architect)", () => {
+  const error = new Error("Prompt Architect failed: boom");
+  assert.equal(resolvePipelineErrorStep(error, STEP_MAP), 1);
+});
+
+test("does not misattribute a message that merely quotes a provider name", () => {
+  // A Gemini error that mentions "Claude" must not be bumped to step 2.
+  const error = new Error('Your prompt mentions "Claude" as a reference model');
+  assert.equal(resolvePipelineErrorStep(error, STEP_MAP), 1);
+});
+
+test("defaults to step 1 for an empty message", () => {
+  assert.equal(resolvePipelineErrorStep(new Error(""), STEP_MAP), 1);
+  assert.equal(resolvePipelineErrorStep(null, STEP_MAP), 1);
+  assert.equal(resolvePipelineErrorStep(undefined, STEP_MAP), 1);
+});
+
+test("falls back to step 1 when the message mentions a product but not a step marker", () => {
+  // "OpenAI" alone is not a reliable generator signal.
+  const error = new Error("OpenAI rate limit exceeded");
+  assert.equal(resolvePipelineErrorStep(error, STEP_MAP), 1);
+});


### PR DESCRIPTION
## Summary

Closes **#13** (Empty catch block and fragile error step detection).

Two related issues in `app.js`, both still present in the current branch:

1. **Empty catch swallowed the real build errors.** The commit error path
   (`app.js`) caught a failed JSON parse of FlutterFlow's error map with
   `catch (e) {}`, so the user saw only a generic "commit failed" without
   FlutterFlow's actual build errors. It now `console.warn`s the parse
   failure.

2. **Fragile error-step detection.** The failed-step resolver
   substring-matched raw provider names (`"Claude"`/`"OpenAI"`) to guess
   the pipeline step — so a Gemini error that merely quoted "Claude"
   would be misattributed to the generator step. Model-armor errors
   already carry a structured `error.pipelineStep`
   (`src/modelArmorResponse.js`), and app.js wraps other errors with its
   own reliable step-prefixed messages. The fallback now matches only
   those reliable markers and defaults to step 1.

Extracted into a tested pure helper **`src/pipelineErrors.js`**
(`resolvePipelineErrorStep`), with 7 new unit tests
(`src/pipelineErrors.test.js`).

## Testing

- New: `src/pipelineErrors.test.js` — 7 cases, including "message quoting
  'Claude' stays on step 1" and "provider name alone is not a step signal".
- Full suite: `npm test` — **128 pass** (was 121).
- `npm run build` (vite) succeeds.

## Scope note

This PR intentionally fixes only #13. The remaining two open issues were
assessed against the current branch and are documented blockers (issue
trackers updated separately):

- **#7 (request cancellation / concurrent-run races)** — verified already
  resolved in the branch: all four async pipeline entry points guard on
  `pipelineState.isRunning` (including `runRefinement`, the specific gap
  #7 flagged), and `callBuildShip` uses an `AbortController` timeout. The
  described race cannot occur; no code change required.
- **#10 (extract the monolith)** and **#11 (global mutable state)** — still
  present, but each already shows partial progress (14 `src/` modules;
  API-key globals replaced by encrypted-storage accessors respectively).
  Completing them is a large, high-risk architectural refactor and is left
  as a documented blocker rather than addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)