### PR TITLE
Catch widget parameters FlutterFlow cannot supply

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ import {
   getDeclaredDartTypes,
   validateBundleCompatibility,
 } from "./src/flutterFlowArtifactValidation.js";
+import { applyFlutterFlowHeader } from "./src/flutterFlowHeader.js";
 import { buildBundleDeployPlan } from "./src/bundleDeployPlanner.js";
 import {
   excludeProvisionedCodeFiles,
@@ -2157,7 +2158,7 @@ import '/flutter_flow/uploaded_file.dart';
   }
 
   return {
-    content: header + cleanedCode,
+    content: applyFlutterFlowHeader(cleanedCode, header),
     fileName,
     codeType,
     artifactType,

--- a/cloud-run/ffai-runner/bin/server.dart
+++ b/cloud-run/ffai-runner/bin/server.dart
@@ -71,6 +71,13 @@ Future<void> _handle(HttpRequest request) async {
     }
 
     final scriptFile = await _writeDeployScript(workspace, classes);
+    // Unlike `ai init`, `ai run`/`ai validate` are passthrough commands: the
+    // CLI forwards these arguments verbatim to the vendored flutterflow_ai SDK,
+    // so whether that SDK honours FF_API_KEY is not something this repo can
+    // verify. Keep --api-key here until a live run proves the env var alone
+    // authenticates; dropping it on assumption would either break every deploy
+    // or, worse, silently fall through to a key left in the shared workspace by
+    // an earlier request.
     final args = <String>[
       'ai',
       dryRun ? 'validate' : 'run',
@@ -161,8 +168,14 @@ Future<_RunOutcome?> _ensureWorkspace(
   final parent = workspace.parent;
   await parent.create(recursive: true);
   final workspaceName = workspace.path.split(Platform.pathSeparator).last;
+  // The key goes via FF_API_KEY only: process arguments are readable from any
+  // process listing and routinely end up in logs, and a FlutterFlow key carries
+  // full project write access. `flutterflow ai init` reads FF_API_KEY directly
+  // (flutterflow_cli ai_router.dart), and deliberately does NOT persist a key
+  // that came from the environment to its credential store - which is what we
+  // want here, because the workspace below is shared across requests.
   final result = await _runFlutterFlow(
-    ['ai', 'init', workspaceName, '--yes', '--api-key', apiKey],
+    ['ai', 'init', workspaceName, '--yes'],
     workingDirectory: parent.path,
     apiKey: apiKey,
     channel: channel,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "node --test src/*.test.js",
     "test:proxies": "php scripts/test-proxy-allowlist.php",
     "test:key-storage": "npm run build && node scripts/test-key-storage.mjs",
-    "verify:buildship-mcp": "node scripts/verify-buildship-mcp.mjs"
+    "verify:buildship-mcp": "node scripts/verify-buildship-mcp.mjs",
+    "audit:widget": "node scripts/audit-ff-widget.mjs"
   },
   "devDependencies": {
     "playwright": "^1.58.2",
@@ -19,6 +20,6 @@
     "vite": "^5.0.0"
   },
   "dependencies": {
-    "posthog-js": "^1.353.0"
+    "posthog-js": "^1.415.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "vite": "^5.0.0"
   },
   "dependencies": {
-    "posthog-js": "^1.415.7"
+    "posthog-js": "^1.353.0"
   }
 }

--- a/scripts/audit-ff-widget.mjs
+++ b/scripts/audit-ff-widget.mjs
@@ -1,0 +1,583 @@
+#!/usr/bin/env node
+/**
+ * audit-ff-widget.mjs - compile-level conformance audit for FlutterFlow custom
+ * widgets, for use during development.
+ *
+ * Adapted from ff_widget_audit.mjs by DanLika
+ * (https://gist.github.com/DanLika/1b775045a4869bddc09a014cec7cfd1d).
+ *
+ * src/flutterFlowArtifactValidation.js can only pattern-match. This harness adds
+ * the two things a pattern cannot do:
+ *
+ *   Stage 1 COMPILE   drops the widget into a real FlutterFlow export and runs
+ *                     `flutter analyze` against real FF scaffolding, so the
+ *                     verdict is the analyzer's rather than a regex's.
+ *   Stage 2 NULL-CALL synthesises the constructor calls FlutterFlow actually
+ *                     emits and compiles THOSE, turning "parameters must be
+ *                     nullable" into a quoted compiler error or into silence.
+ *
+ * Stage 3 deliberately imports the shipped rules instead of restating them:
+ * two copies of a rule set drift, and a stale copy here would disagree with
+ * what actually gates a deploy.
+ *
+ * Usage:
+ *   node scripts/audit-ff-widget.mjs <file.dart|dir>... --export <generated_code>
+ *   node scripts/audit-ff-widget.mjs --self-test        --export <generated_code>
+ *
+ * Run `flutter pub get` in the export once before the first audit. Audit files
+ * go into an isolated symlink worktree under os.tmpdir(), so the live export is
+ * never written to and FlutterFlow Desktop cannot race the harness.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync,
+  statSync, symlinkSync, unlinkSync, writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  calibrateWidgetRules,
+  getWidgetRuleFindings,
+} from "../src/flutterFlowArtifactValidation.js";
+
+const FF_HEADER_TEMPLATE = `// Automatic FlutterFlow imports
+import '/backend/schema/structs/index.dart';
+import '/flutter_flow/flutter_flow_theme.dart';
+import '/flutter_flow/flutter_flow_util.dart';
+import '/custom_code/widgets/index.dart'; // Imports other custom widgets
+import '/custom_code/actions/index.dart'; // Imports custom actions
+import '/flutter_flow/custom_functions.dart'; // Imports custom functions
+import 'package:flutter/material.dart';
+// Begin custom widget code
+// DO NOT REMOVE OR MODIFY THE CODE ABOVE!
+`;
+
+// FlutterFlow only emits a header line for scaffolding the project actually
+// has: an export with no Data Types has no /backend/schema/structs/index.dart.
+// Pasting the full template into such an export makes the harness produce its
+// own `uri_does_not_exist` error and report it against the widget. Measured on
+// a real export - the self-test refused to go green until this was filtered.
+let FF_HEADER = FF_HEADER_TEMPLATE;
+
+function configureHeader(exportDir) {
+  FF_HEADER = FF_HEADER_TEMPLATE
+    .split("\n")
+    .filter((line) => {
+      const uri = (/^\s*import\s+['"]\/([^'"]+)['"]/.exec(line) || [])[1];
+      return uri === undefined || existsSync(join(exportDir, "lib", uri));
+    })
+    .join("\n");
+}
+
+// FlutterFlow's OWN shipped widgets produce these against this header, so they
+// are the instrument's noise floor, not a finding about the widget.
+const BOILERPLATE_NOISE = /unused_import|unnecessary_import/;
+
+const COLOR = {
+  red: "\x1b[31m", yellow: "\x1b[33m", green: "\x1b[32m",
+  dim: "\x1b[2m", bold: "\x1b[1m", off: "\x1b[0m",
+};
+
+const paint = (severity, text) =>
+  (severity === "error" ? COLOR.red : severity === "warning" ? COLOR.yellow : COLOR.dim)
+  + text + COLOR.off;
+
+/** Blanks comments and string bodies so patterns never match prose. */
+function strip(code) {
+  let out = "";
+  let i = 0;
+
+  while (i < code.length) {
+    const pair = code.slice(i, i + 2);
+
+    if (pair === "//") {
+      while (i < code.length && code[i] !== "\n") i++;
+      out += " ";
+    } else if (pair === "/*") {
+      i += 2;
+      while (i < code.length && code.slice(i, i + 2) !== "*/") i++;
+      i += 2;
+      out += " ";
+    } else if (code[i] === "'" || code[i] === '"') {
+      const quote = code[i];
+      i++;
+      while (i < code.length && code[i] !== quote) {
+        if (code[i] === "\\") i++;
+        i++;
+      }
+      i++;
+      out += '""';
+    } else {
+      out += code[i];
+      i++;
+    }
+  }
+
+  return out;
+}
+
+/**
+ * [A-Z] is deliberate: a private helper (`_Row extends StatelessWidget`) is not
+ * placeable from the FlutterFlow panel and must never become the audit subject.
+ */
+function readWidgetClassName(code) {
+  const match = /class\s+([A-Z]\w*)\s+extends\s+Stat(?:eless|eful)Widget/.exec(strip(code));
+  return match ? match[1] : null;
+}
+
+function readClassSpan(code, className) {
+  const header = new RegExp(`class\\s+${className}\\b[^{]*\\{`).exec(code);
+  if (!header) return null;
+
+  let depth = 0;
+
+  for (let i = header.index + header[0].length - 1; i < code.length; i++) {
+    if (code[i] === "{") depth++;
+    else if (code[i] === "}" && --depth === 0) return code.slice(header.index, i + 1);
+  }
+
+  return null;
+}
+
+/**
+ * Reads the widget's OWN constructor parameters - the only names FlutterFlow's
+ * Define Parameters panel can emit. Collecting `final` fields off the whole file
+ * instead pushes helper-class fields into the synthesized call and manufactures
+ * "isn't defined" errors that belong to the harness, not the widget.
+ */
+function readConstructorParams(code, className) {
+  const body = readClassSpan(strip(code), className);
+  if (!body) return { named: [] };
+
+  const ctor = new RegExp(`(?:const\\s+)?${className}\\s*\\(`).exec(body);
+  if (!ctor) return { named: [] };
+
+  let depth = 0;
+  let i = ctor.index + ctor[0].length - 1;
+  const start = i + 1;
+
+  for (; i < body.length; i++) {
+    if (body[i] === "(") depth++;
+    else if (body[i] === ")" && --depth === 0) break;
+  }
+
+  const source = body.slice(start, i);
+  const braceStart = source.indexOf("{");
+  if (braceStart === -1) return { named: [] };
+
+  const namedSource = source.slice(braceStart + 1, source.lastIndexOf("}"));
+  const parts = [];
+  let nesting = 0;
+  let current = "";
+
+  for (const char of namedSource) {
+    if ("({[<".includes(char)) nesting++;
+    else if (")}]>".includes(char)) nesting--;
+
+    if (char === "," && nesting === 0) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  if (current.trim()) parts.push(current);
+
+  const named = parts.map((part) => part.trim()).filter(Boolean).flatMap((part) => {
+    if (/\bsuper\.key\b|Key\?\s*key/.test(part)) return [];
+    const name = (/this\.(\w+)/.exec(part) || /(\w+)\s*(?:=|$)/.exec(part) || [])[1];
+    return name ? [name] : [];
+  });
+
+  return { named };
+}
+
+const hasFfHeader = (code) => /DO NOT REMOVE OR MODIFY THE CODE ABOVE/.test(code);
+
+/**
+ * Prepends FlutterFlow's real header, dropping imports it already provides.
+ * Matching on the import URI rather than the whole line matters: FF's header
+ * carries trailing comments that generated files omit, so a line-equality
+ * filter leaves duplicates behind and the harness reports its own noise as a
+ * defect of the widget.
+ */
+function withFfHeader(code) {
+  if (hasFfHeader(code)) return code;
+
+  const readUri = (line) => (/^\s*import\s+['"]([^'"]+)['"]/.exec(line) || [])[1];
+  const headerUris = new Set((FF_HEADER.match(/^import .*$/gm) || []).map(readUri));
+  const body = code
+    .split("\n")
+    .filter((line) => !headerUris.has(readUri(line)))
+    .join("\n")
+    .replace(/^\s*\/\/ Automatic FlutterFlow imports\s*$/m, "");
+
+  return `${FF_HEADER}\n${body}`;
+}
+
+/**
+ * Builds an isolated analyze root: symlink the live export, but keep
+ * lib/custom_code/widgets/ a REAL directory so `_audit_*` files never land in
+ * the project FlutterFlow Desktop is watching. package_config.json is copied
+ * rather than symlinked so its `rootUri: "../"` resolves to this worktree.
+ */
+function openWorktree(exportDir) {
+  const root = mkdtempSync(join(tmpdir(), "ffaudit-wt-"));
+
+  for (const name of readdirSync(exportDir)) {
+    if (name === "lib" || name === ".dart_tool" || name === "build") continue;
+    symlinkSync(join(exportDir, name), join(root, name));
+  }
+
+  const walkLib = (rel) => {
+    for (const name of readdirSync(join(exportDir, rel))) {
+      const source = join(exportDir, rel, name);
+      const relPath = join(rel, name);
+      const destination = join(root, relPath);
+
+      if (statSync(source).isDirectory()) {
+        mkdirSync(destination, { recursive: true });
+        if (relPath.replace(/\\/g, "/") === "lib/custom_code/widgets") {
+          for (const file of readdirSync(source)) {
+            symlinkSync(join(source, file), join(destination, file));
+          }
+        } else {
+          walkLib(relPath);
+        }
+      } else {
+        mkdirSync(dirname(destination), { recursive: true });
+        symlinkSync(source, destination);
+      }
+    }
+  };
+
+  walkLib("lib");
+  mkdirSync(join(root, ".dart_tool"), { recursive: true });
+  writeFileSync(
+    join(root, ".dart_tool/package_config.json"),
+    readFileSync(join(exportDir, ".dart_tool/package_config.json")),
+  );
+
+  for (const name of readdirSync(join(exportDir, ".dart_tool"))) {
+    if (name === "package_config.json") continue;
+    symlinkSync(join(exportDir, ".dart_tool", name), join(root, ".dart_tool", name));
+  }
+
+  return root;
+}
+
+function runAnalyzer(workDir, relPaths) {
+  try {
+    execFileSync("flutter", ["analyze", ...relPaths], {
+      cwd: workDir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return [];
+  } catch (error) {
+    const text = `${error.stdout || ""}${error.stderr || ""}`;
+
+    if (/Unable to find|No such file|command not found/.test(text) && !/•/.test(text)) {
+      throw new Error(`flutter analyze could not run:\n${text.trim()}`);
+    }
+
+    return text.split("\n")
+      .map((line) => line.trim())
+      .filter((line) => /^(error|warning|info)\s+•/.test(line))
+      .map((line) => {
+        const [severity, ...rest] = line.split("•").map((part) => part.trim());
+        return { severity, message: rest[0] || "", where: rest[1] || "", code: rest[2] || "" };
+      });
+  }
+}
+
+/** Stage 1: compile the widget against real FlutterFlow scaffolding. */
+function stageCompile(workDir, code, tag) {
+  const rel = `lib/custom_code/widgets/_audit_${tag}.dart`;
+  writeFileSync(join(workDir, rel), withFfHeader(code));
+
+  try {
+    const all = runAnalyzer(workDir, [rel]);
+    return {
+      errors: all.filter((d) => d.severity === "error"),
+      warnings: all.filter((d) => d.severity === "warning" && !BOILERPLATE_NOISE.test(d.code)),
+      suppressed: all.filter((d) => BOILERPLATE_NOISE.test(d.code)).length,
+    };
+  } finally {
+    try { unlinkSync(join(workDir, rel)); } catch { /* already gone */ }
+  }
+}
+
+/**
+ * Stage 2: compile the two constructor calls FlutterFlow emits, in SEPARATE
+ * files so a failure attributes by construction rather than by guessing at
+ * error codes.
+ *
+ *   A  nothing set - `Cls()`, what FF emits when every Define Parameters field
+ *      is left blank. Unset parameters are omitted, not passed as null. An
+ *      error here is a hard fail: the widget cannot be placed at all.
+ *   B  all null    - `Cls(a: null, ...)`, what a parameter bound to a nullable
+ *      value degenerates to. An error only here is a warning: defaults rescue
+ *      the blank panel, but any null binding breaks it.
+ *
+ * Merging the two shapes reports a defaulted non-nullable widget - which
+ * FlutterFlow instantiates fine - as "cannot instantiate". Hence the split.
+ *
+ * The import is prefixed `as aud` because the audited class often also arrives
+ * via the header's index.dart export, and an unprefixed name is ambiguous.
+ */
+function stageNullCall(workDir, code, tag) {
+  const className = readWidgetClassName(code);
+  if (!className) return { skipped: "no widget class found" };
+
+  const widgetRel = `lib/custom_code/widgets/_audit_${tag}.dart`;
+  const callARel = `lib/custom_code/widgets/_audit_call_a_${tag}.dart`;
+  const callBRel = `lib/custom_code/widgets/_audit_call_b_${tag}.dart`;
+  const allNull = readConstructorParams(code, className).named
+    .map((name) => `${name}: null`)
+    .join(", ");
+
+  writeFileSync(join(workDir, widgetRel), withFfHeader(code));
+  writeFileSync(join(workDir, callARel),
+    `${FF_HEADER}\nimport '_audit_${tag}.dart' as aud;\n\nWidget ffEmitsNothingSet() => aud.${className}();\n`);
+  writeFileSync(join(workDir, callBRel),
+    `${FF_HEADER}\nimport '_audit_${tag}.dart' as aud;\n\nWidget ffEmitsEveryFieldNull() => aud.${className}(${allNull});\n`);
+
+  try {
+    const diagnostics = runAnalyzer(workDir, [callARel, callBRel])
+      .filter((d) => d.severity === "error");
+    const inFile = (rel) => diagnostics.filter((d) => d.where.includes(basename(rel)));
+
+    return {
+      exercisedFields: readConstructorParams(code, className).named.length,
+      hard: inFile(callARel),
+      soft: inFile(callBRel),
+    };
+  } finally {
+    for (const rel of [widgetRel, callARel, callBRel]) {
+      try { unlinkSync(join(workDir, rel)); } catch { /* already gone */ }
+    }
+  }
+}
+
+function auditFile(path, workDir) {
+  const raw = readFileSync(path, "utf8");
+  const tag = basename(path).replace(/\W/g, "_").toLowerCase();
+  const className = readWidgetClassName(raw);
+  const compile = stageCompile(workDir, raw, tag);
+
+  // Stage 1 errors make a blank-panel call meaningless; reporting "compiles"
+  // there greenwashes a broken widget.
+  let nullCall;
+  if (!className) {
+    nullCall = { skipped: "no widget class found" };
+  } else if (compile.errors.length > 0) {
+    nullCall = {
+      blocked: `stage 1 has ${compile.errors.length} compile error(s) - blank-panel call not meaningful until the widget itself compiles`,
+      hard: [], soft: [], exercisedFields: 0,
+    };
+  } else {
+    nullCall = stageNullCall(workDir, raw, tag);
+  }
+
+  return { path, className, findings: getWidgetRuleFindings(raw), compile, nullCall };
+}
+
+function printReport(report) {
+  const subject = report.className ? `(${report.className})` : "(no widget class)";
+  console.log(`\n${COLOR.bold}=== ${basename(report.path)} ${subject} ===${COLOR.off}`);
+
+  console.log(`\n  ${COLOR.bold}1. COMPILE${COLOR.off} - flutter analyze against a real FlutterFlow export`);
+  const diagnostics = [...report.compile.errors, ...report.compile.warnings];
+  if (diagnostics.length === 0) {
+    console.log(`     ${COLOR.green}clean${COLOR.off}  ${COLOR.dim}(${report.compile.suppressed} boilerplate import notices suppressed)${COLOR.off}`);
+  }
+  for (const d of diagnostics) {
+    console.log(`     ${paint(d.severity, d.severity.padEnd(7))} ${d.message}  ${COLOR.dim}${d.code}${COLOR.off}`);
+  }
+
+  console.log(`\n  ${COLOR.bold}2. NULL-CALL${COLOR.off} - the constructor calls FlutterFlow actually emits`);
+  if (report.nullCall.skipped) {
+    console.log(`     ${COLOR.dim}skipped: ${report.nullCall.skipped}${COLOR.off}`);
+  } else if (report.nullCall.blocked) {
+    console.log(`     ${COLOR.dim}blocked: ${report.nullCall.blocked}${COLOR.off}`);
+  } else if (report.nullCall.hard.length > 0) {
+    console.log(`     ${COLOR.red}HARD FAIL${COLOR.off} - the blank-panel call \`${report.className}()\` does not compile; the widget cannot be placed at all:`);
+    for (const d of report.nullCall.hard.slice(0, 6)) console.log(`       ${COLOR.red}error${COLOR.off} ${d.message}`);
+  } else if (report.nullCall.soft.length > 0) {
+    console.log(`     ${COLOR.green}blank panel OK${COLOR.off} (defaults rescue it), ${COLOR.yellow}but any parameter bound to a null value fails:${COLOR.off}`);
+    for (const d of report.nullCall.soft.slice(0, 6)) console.log(`       ${COLOR.yellow}warning${COLOR.off} ${d.message}`);
+  } else {
+    console.log(`     ${COLOR.green}compiles${COLOR.off} blank and with all ${report.nullCall.exercisedFields} parameters explicitly null`);
+  }
+
+  console.log(`\n  ${COLOR.bold}3. RULES${COLOR.off} - the same rules that gate a deploy`);
+  if (report.findings.length === 0) console.log(`     ${COLOR.green}none triggered${COLOR.off}`);
+  for (const finding of report.findings) {
+    console.log(`     ${paint(finding.severity, finding.severity.padEnd(7))} ${COLOR.bold}${finding.id}${COLOR.off}`);
+    console.log(`             ${finding.message}`);
+  }
+}
+
+const SELF_TEST_WIDGETS = {
+  // required param -> blank-panel call must not compile
+  "hard_required.dart": `class HardRequired extends StatefulWidget {
+  const HardRequired({Key? key, required this.value}) : super(key: key);
+  final double value;
+  @override State<HardRequired> createState() => _HardRequiredState();
+}
+class _HardRequiredState extends State<HardRequired> {
+  @override Widget build(BuildContext context) => Text('\${widget.value}');
+}`,
+  // defaulted non-nullable -> blank panel fine, explicit null fails
+  "soft_defaulted.dart": `class SoftDefaulted extends StatefulWidget {
+  const SoftDefaulted({Key? key, this.value = 1.0}) : super(key: key);
+  final double value;
+  @override State<SoftDefaulted> createState() => _SoftDefaultedState();
+}
+class _SoftDefaultedState extends State<SoftDefaulted> {
+  @override Widget build(BuildContext context) => Text('\${widget.value}');
+}`,
+  // fully nullable -> compiles both ways
+  "clean_nullable.dart": `class CleanNullable extends StatefulWidget {
+  const CleanNullable({Key? key, this.width, this.height}) : super(key: key);
+  final double? width;
+  final double? height;
+  @override State<CleanNullable> createState() => _CleanNullableState();
+}
+class _CleanNullableState extends State<CleanNullable> {
+  @override Widget build(BuildContext context) => SizedBox(width: widget.width, height: widget.height);
+}`,
+  // does not compile -> stage 2 must be blocked, never greenwashed
+  "blocked_garbage.dart": `class BlockedGarbage extends StatefulWidget {
+  const BlockedGarbage({Key? key}) : super(key: key);
+  @override State<BlockedGarbage> createState() => _BlockedGarbageState();
+}
+class _BlockedGarbageState extends State<BlockedGarbage> {
+  @override Widget build(BuildContext context) => ThisTypeDoesNotExist();
+}`,
+};
+
+const SELF_TEST_CONTROLS = [
+  {
+    id: "hard-required",
+    file: "hard_required.dart",
+    check: (r) => !r.nullCall.blocked && r.nullCall.hard.length > 0,
+    fail: "a required param must HARD FAIL the blank-panel call",
+  },
+  {
+    id: "soft-defaulted",
+    file: "soft_defaulted.dart",
+    check: (r) => !r.nullCall.blocked && r.nullCall.hard.length === 0 && r.nullCall.soft.length > 0,
+    fail: "a defaulted non-nullable must be blank-OK but fail the null binding",
+  },
+  {
+    id: "clean-nullable",
+    file: "clean_nullable.dart",
+    check: (r) => r.compile.errors.length === 0 && !r.nullCall.blocked
+      && r.nullCall.hard.length === 0 && r.nullCall.soft.length === 0,
+    fail: "an all-nullable widget must compile blank and with explicit nulls",
+  },
+  {
+    id: "blocked-garbage",
+    file: "blocked_garbage.dart",
+    check: (r) => r.compile.errors.length > 0 && Boolean(r.nullCall.blocked),
+    fail: "stage-1 errors must block stage 2 (no greenwashed 'compiles')",
+  },
+];
+
+function runSelfTest(workDir) {
+  const scratch = mkdtempSync(join(tmpdir(), "ffaudit-controls-"));
+  let failed = 0;
+
+  for (const [name, source] of Object.entries(SELF_TEST_WIDGETS)) {
+    writeFileSync(join(scratch, name), source);
+  }
+
+  for (const control of SELF_TEST_CONTROLS) {
+    const report = auditFile(join(scratch, control.file), workDir);
+    printReport(report);
+    const ok = control.check(report);
+    console.log(`\n  control ${control.id}: ${ok ? `${COLOR.green}PASS${COLOR.off}` : `${COLOR.red}FAIL - ${control.fail}${COLOR.off}`}`);
+    if (!ok) failed++;
+  }
+
+  rmSync(scratch, { recursive: true, force: true });
+  return failed;
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const exportIndex = argv.indexOf("--export");
+  const exportDir = exportIndex !== -1 ? resolve(argv[exportIndex + 1]) : process.env.FF_EXPORT;
+  const targets = argv.filter((arg, i) => !arg.startsWith("--") && i !== exportIndex + 1);
+  const selfTest = argv.includes("--self-test");
+
+  if (!exportDir) {
+    console.error("Need --export <path to a FlutterFlow generated_code dir> (or $FF_EXPORT).");
+    console.error("Run `flutter pub get` in it once before the first audit.");
+    process.exit(2);
+  }
+  if (!existsSync(join(exportDir, ".dart_tool/package_config.json"))) {
+    console.error(`No package_config in ${exportDir} - run \`flutter pub get\` there first.`);
+    process.exit(2);
+  }
+
+  // A rule that cannot flag its own positive control reports nothing, and its
+  // silence would read as a clean widget. Surface that before any verdict.
+  const voided = calibrateWidgetRules().filter((result) => !result.usable);
+  console.log(`${COLOR.bold}Rule calibration${COLOR.off} - a rule reports only after flagging its positive control and staying silent on its negative one.`);
+  console.log(`  usable ${calibrateWidgetRules().length - voided.length}/${calibrateWidgetRules().length}`);
+  for (const result of voided) {
+    console.log(`  ${COLOR.red}VOID${COLOR.off} ${result.id} - positive:${result.positiveOk ? "ok" : "FAILED"} negative:${result.negativeOk ? "ok" : "FAILED"} (suppressed, will not report)`);
+  }
+
+  configureHeader(exportDir);
+
+  const liveWidgets = join(exportDir, "lib/custom_code/widgets");
+  const liveBefore = new Set(existsSync(liveWidgets) ? readdirSync(liveWidgets) : []);
+  const workDir = openWorktree(exportDir);
+
+  try {
+    let failures = 0;
+
+    if (selfTest) {
+      failures = runSelfTest(workDir);
+    } else {
+      const files = targets.flatMap((target) => statSync(target).isDirectory()
+        ? readdirSync(target)
+          .filter((name) => name.endsWith(".dart") && name !== "index.dart")
+          .map((name) => join(target, name))
+        : [target]);
+
+      if (files.length === 0) {
+        console.error("\nNo .dart files given. Pass files or a directory, or --self-test.");
+        process.exit(2);
+      }
+
+      for (const file of files) {
+        const report = auditFile(file, workDir);
+        printReport(report);
+        failures += report.compile.errors.length
+          + (report.nullCall.hard?.length || 0)
+          + report.findings.filter((finding) => finding.severity === "error").length;
+      }
+    }
+
+    const liveAfter = new Set(existsSync(liveWidgets) ? readdirSync(liveWidgets) : []);
+    const leaked = [...liveAfter].filter((name) => !liveBefore.has(name));
+
+    console.log(`\n${COLOR.bold}--- verdict ---${COLOR.off}`);
+    console.log(`  isolation (live export untouched): ${leaked.length === 0 ? `${COLOR.green}PASS${COLOR.off}` : `${COLOR.red}FAIL - leaked ${leaked.join(", ")}${COLOR.off}`}`);
+    console.log(`  ${failures} error-level finding(s)`);
+    if (voided.length > 0) {
+      console.log(`${COLOR.red}  ${voided.length} rule(s) VOID - their silence proves nothing.${COLOR.off}`);
+    }
+
+    process.exit(failures > 0 || leaked.length > 0 ? 1 : 0);
+  } finally {
+    try { rmSync(workDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+}
+
+main();

--- a/scripts/audit-ff-widget.mjs
+++ b/scripts/audit-ff-widget.mjs
@@ -40,6 +40,7 @@ import {
   calibrateWidgetRules,
   getWidgetRuleFindings,
 } from "../src/flutterFlowArtifactValidation.js";
+import { applyFlutterFlowHeader } from "../src/flutterFlowHeader.js";
 
 const FF_HEADER_TEMPLATE = `// Automatic FlutterFlow imports
 import '/backend/schema/structs/index.dart';
@@ -197,23 +198,13 @@ const hasFfHeader = (code) => /DO NOT REMOVE OR MODIFY THE CODE ABOVE/.test(code
 
 /**
  * Prepends FlutterFlow's real header, dropping imports it already provides.
- * Matching on the import URI rather than the whole line matters: FF's header
- * carries trailing comments that generated files omit, so a line-equality
- * filter leaves duplicates behind and the harness reports its own noise as a
- * defect of the widget.
+ * Delegates to the shipped normalizer so the harness cannot disagree with what
+ * the deploy path actually writes - and so its import handling stays correct:
+ * matching on URI alone would drop a prefixed `as` import and make the analyzer
+ * report unresolved references that belong to the harness, not the widget.
  */
 function withFfHeader(code) {
-  if (hasFfHeader(code)) return code;
-
-  const readUri = (line) => (/^\s*import\s+['"]([^'"]+)['"]/.exec(line) || [])[1];
-  const headerUris = new Set((FF_HEADER.match(/^import .*$/gm) || []).map(readUri));
-  const body = code
-    .split("\n")
-    .filter((line) => !headerUris.has(readUri(line)))
-    .join("\n")
-    .replace(/^\s*\/\/ Automatic FlutterFlow imports\s*$/m, "");
-
-  return `${FF_HEADER}\n${body}`;
+  return hasFfHeader(code) ? code : applyFlutterFlowHeader(code, `${FF_HEADER}\n`);
 }
 
 /**

--- a/src/flutterFlowArtifactValidation.js
+++ b/src/flutterFlowArtifactValidation.js
@@ -84,7 +84,17 @@ const WIDGET_RULES = [
       let match;
 
       while ((match = fieldPattern.exec(span)) !== null) {
-        if (!new RegExp(`this\\.${match[1]}\\s*=`).test(span)) return true;
+        const field = match[1];
+        // Two forms keep a blank panel constructible: a default on the
+        // parameter (`this.x = 0.0`), and an initializer list entry
+        // (`const W() : x = 1`, `const W({double? v}) : x = v ?? 1.0`), where
+        // the widget supplies the value itself and never exposes a parameter
+        // at all. Only the parameter form was recognised, so an
+        // initializer-list field was reported as an error and blocked a deploy
+        // the compiler was perfectly happy with.
+        const hasDefault = new RegExp(`this\\.${field}\\s*=(?!=)`).test(span)
+          || new RegExp(`[:,]\\s*${field}\\s*=(?!=)`).test(span);
+        if (!hasDefault) return true;
       }
 
       return false;

--- a/src/flutterFlowArtifactValidation.js
+++ b/src/flutterFlowArtifactValidation.js
@@ -49,6 +49,68 @@ const SUPPORTED_RETURN_TYPES = new Set([
 // "<Collection>Record", so both suffixes are selectable return values.
 const SUPPORTED_RETURN_TYPE_SUFFIXES = ["Struct", "Record"];
 
+// Unset FlutterFlow "Define Parameters" fields are OMITTED from the constructor
+// call FlutterFlow emits, not passed as null. So a `required` parameter, or a
+// non-nullable field with no constructor default, makes that call fail to
+// compile and the widget cannot be placed at all.
+//
+// Both rules are scoped to public Stat*Widget classes on purpose: private
+// helpers and painters are not placeable from the FlutterFlow panel and use
+// `required` legitimately. Judging the whole file instead flags healthy widgets.
+const WIDGET_RULES = [
+  {
+    id: "required-public-param",
+    severity: "error",
+    message:
+      "CustomWidget constructor uses `required` on a parameter FlutterFlow can leave unset. "
+      + "FlutterFlow omits unset Define Parameters fields from the constructor call, so the widget "
+      + "will not compile when placed. Make the parameter optional and nullable (`this.value` with "
+      + "`final double? value`), or give it a constructor default (`this.value = 0.0`).",
+    detect: (stripped) => /\brequired\s+this\.\w+/.test(getPublicWidgetSpans(stripped)),
+    pos: "class W extends StatefulWidget { const W({required this.value}); final double value; }",
+    neg: "class _P { const _P({required this.t}); final double t; }\n"
+      + "class W extends StatefulWidget { const W({this.value}); final double? value; }",
+  },
+  {
+    id: "non-nullable-public-field",
+    severity: "error",
+    message:
+      "CustomWidget declares a non-nullable field with no constructor default. FlutterFlow omits "
+      + "unset Define Parameters fields, so the emitted call cannot supply it. Make the field "
+      + "nullable (`final double? value`) or give the parameter a default (`this.value = 0.0`).",
+    detect: (stripped) => {
+      const span = getPublicWidgetSpans(stripped);
+      const fieldPattern = /^\s*final\s+(?:double|int|String|bool|Color|num)\s+(\w+)\s*;/gm;
+      let match;
+
+      while ((match = fieldPattern.exec(span)) !== null) {
+        if (!new RegExp(`this\\.${match[1]}\\s*=`).test(span)) return true;
+      }
+
+      return false;
+    },
+    // Multi-line on purpose: the detector anchors `^\s*final`, so a single-line
+    // control never matches and would void the rule.
+    pos: "class W extends StatefulWidget {\n  const W({required this.value});\n  final double value;\n}",
+    neg: "class _P {\n  const _P({required this.t});\n  final double t;\n}\n"
+      + "class W extends StatefulWidget {\n  const W({this.value = 1.0});\n  final double value;\n}",
+  },
+  {
+    id: "asset-without-anchor",
+    severity: "warning",
+    message:
+      "CustomWidget calls Image.asset with a path arriving as a String parameter. An asset reaches "
+      + "the build only when a FlutterFlow widget NODE references it - a filename passed as a "
+      + "parameter does not count, so the image renders as a broken-image icon on device. "
+      + "\"Download Unused Project Assets\" does not fix it (FlutterFlow issues 522, 2271, 3799). "
+      + "Keep something in the UI referencing the file, or load it over the network instead.",
+    detect: (stripped) =>
+      /Image\.asset\s*\(/.test(stripped) && /final\s+String\??\s+\w*[Pp]ath\b/.test(stripped),
+    pos: "class W extends StatefulWidget { final String? imagePath; }\nvar x = Image.asset(widget.imagePath);",
+    neg: "class W extends StatefulWidget { final String? imagePath; }\nvar x = Image.network(widget.imagePath);",
+  },
+];
+
 function createFinding(artifact, severity, message) {
   return {
     artifactId: artifact.id,
@@ -117,6 +179,82 @@ function readBalancedGeneric(code, start) {
   }
 
   return null;
+}
+
+/**
+ * Returns the brace-matched body of `class <name> ... { ... }`, which a regex
+ * cannot do - a widget body contains nested braces on every build method.
+ * @param {string} code - Source with comments and strings removed
+ * @param {string} className - Class to extract
+ * @returns {string|null} Full `class ... { ... }` text, or null
+ */
+function readClassSpan(code, className) {
+  const header = new RegExp(`class\\s+${className}\\b[^{]*\\{`).exec(code);
+  if (!header) return null;
+
+  let depth = 0;
+
+  for (let i = header.index + header[0].length - 1; i < code.length; i++) {
+    if (code[i] === "{") depth++;
+    else if (code[i] === "}" && --depth === 0) return code.slice(header.index, i + 1);
+  }
+
+  return null;
+}
+
+/**
+ * Joins the body of every PUBLIC Stat*Widget class in the source - the only
+ * code FlutterFlow's Define Parameters panel can emit a constructor call for.
+ * Private helpers (`_Row extends StatelessWidget`), painters, and plain data
+ * classes are excluded: they are not placeable, so `required` is fine there.
+ * @param {string} code - Source with comments and strings removed
+ * @returns {string} Concatenated public widget class bodies
+ */
+function getPublicWidgetSpans(code) {
+  const spans = [];
+  const declarations = code.matchAll(/class\s+([A-Z]\w*)\s+extends\s+Stat(?:eless|eful)Widget/g);
+
+  for (const declaration of declarations) {
+    const span = readClassSpan(code, declaration[1]);
+    if (span) spans.push(span);
+  }
+
+  return spans.join("\n");
+}
+
+/**
+ * Proves a rule can see the defect it claims to detect before it is allowed to
+ * report. A rule must flag its positive control and stay silent on its negative
+ * one; otherwise it is unusable and its silence proves nothing.
+ * @param {object} rule - Rule with detect/pos/neg
+ * @returns {{id: string, positiveOk: boolean, negativeOk: boolean, usable: boolean}}
+ */
+export function calibrateRule(rule) {
+  const positiveOk = rule.detect(stripCommentsAndStrings(rule.pos)) === true;
+  const negativeOk = rule.detect(stripCommentsAndStrings(rule.neg)) === false;
+
+  return { id: rule.id, positiveOk, negativeOk, usable: positiveOk && negativeOk };
+}
+
+export function calibrateWidgetRules() {
+  return WIDGET_RULES.map(calibrateRule);
+}
+
+// Calibrated once at load: a rule broken by a later edit is suppressed rather
+// than silently reporting every widget as clean.
+const USABLE_WIDGET_RULES = WIDGET_RULES.filter((rule) => calibrateRule(rule).usable);
+
+/**
+ * Runs the calibrated CustomWidget pattern rules over Dart source.
+ * @param {string} code - Dart source
+ * @returns {Array<{id: string, severity: string, message: string}>} Triggered rules
+ */
+export function getWidgetRuleFindings(code = "") {
+  const stripped = stripCommentsAndStrings(code);
+
+  return USABLE_WIDGET_RULES
+    .filter((rule) => rule.detect(stripped))
+    .map(({ id, severity, message }) => ({ id, severity, message }));
 }
 
 /**
@@ -310,12 +448,18 @@ export function validateArtifactCompatibility(artifact, options = {}) {
     return findings;
   }
 
-  if (artifact.artifactType === "CustomWidget" && !/class\s+\w+\s+extends\s+(StatelessWidget|StatefulWidget)/.test(code)) {
-    findings.push(createFinding(
-      artifact,
-      "warning",
-      "CustomWidget code should declare a widget class extending StatelessWidget or StatefulWidget.",
-    ));
+  if (artifact.artifactType === "CustomWidget") {
+    if (!/class\s+\w+\s+extends\s+(StatelessWidget|StatefulWidget)/.test(code)) {
+      findings.push(createFinding(
+        artifact,
+        "warning",
+        "CustomWidget code should declare a widget class extending StatelessWidget or StatefulWidget.",
+      ));
+    }
+
+    for (const rule of getWidgetRuleFindings(code)) {
+      findings.push(createFinding(artifact, rule.severity, rule.message));
+    }
   }
 
   if (

--- a/src/flutterFlowArtifactValidation.js
+++ b/src/flutterFlowArtifactValidation.js
@@ -66,7 +66,8 @@ const WIDGET_RULES = [
       + "FlutterFlow omits unset Define Parameters fields from the constructor call, so the widget "
       + "will not compile when placed. Make the parameter optional and nullable (`this.value` with "
       + "`final double? value`), or give it a constructor default (`this.value = 0.0`).",
-    detect: (stripped) => /\brequired\s+this\.\w+/.test(getPublicWidgetSpans(stripped)),
+    detect: (stripped) => getPublicWidgetSpans(stripped)
+      .some((span) => /\brequired\s+this\.\w+/.test(span)),
     pos: "class W extends StatefulWidget { const W({required this.value}); final double value; }",
     neg: "class _P { const _P({required this.t}); final double t; }\n"
       + "class W extends StatefulWidget { const W({this.value}); final double? value; }",
@@ -78,8 +79,10 @@ const WIDGET_RULES = [
       "CustomWidget declares a non-nullable field with no constructor default. FlutterFlow omits "
       + "unset Define Parameters fields, so the emitted call cannot supply it. Make the field "
       + "nullable (`final double? value`) or give the parameter a default (`this.value = 0.0`).",
-    detect: (stripped) => {
-      const span = getPublicWidgetSpans(stripped);
+    // Each class is judged against its OWN body. A field's default has to come
+    // from the constructor that builds that widget; a sibling widget in the
+    // same file declaring `this.value = 0.0` says nothing about this one.
+    detect: (stripped) => getPublicWidgetSpans(stripped).some((span) => {
       const fieldPattern = /^\s*final\s+(?:double|int|String|bool|Color|num)\s+(\w+)\s*;/gm;
       let match;
 
@@ -89,16 +92,14 @@ const WIDGET_RULES = [
         // parameter (`this.x = 0.0`), and an initializer list entry
         // (`const W() : x = 1`, `const W({double? v}) : x = v ?? 1.0`), where
         // the widget supplies the value itself and never exposes a parameter
-        // at all. Only the parameter form was recognised, so an
-        // initializer-list field was reported as an error and blocked a deploy
-        // the compiler was perfectly happy with.
+        // at all.
         const hasDefault = new RegExp(`this\\.${field}\\s*=(?!=)`).test(span)
           || new RegExp(`[:,]\\s*${field}\\s*=(?!=)`).test(span);
         if (!hasDefault) return true;
       }
 
       return false;
-    },
+    }),
     // Multi-line on purpose: the detector anchors `^\s*final`, so a single-line
     // control never matches and would void the rule.
     pos: "class W extends StatefulWidget {\n  const W({required this.value});\n  final double value;\n}",
@@ -213,12 +214,18 @@ function readClassSpan(code, className) {
 }
 
 /**
- * Joins the body of every PUBLIC Stat*Widget class in the source - the only
- * code FlutterFlow's Define Parameters panel can emit a constructor call for.
- * Private helpers (`_Row extends StatelessWidget`), painters, and plain data
- * classes are excluded: they are not placeable, so `required` is fine there.
+ * Returns the body of every PUBLIC Stat*Widget class in the source, one entry
+ * per class - the only code FlutterFlow's Define Parameters panel can emit a
+ * constructor call for. Private helpers (`_Row extends StatelessWidget`),
+ * painters, and plain data classes are excluded: they are not placeable, so
+ * `required` is fine there.
+ *
+ * Kept separate rather than concatenated because a rule that asks "does this
+ * field have a default?" must ask it of one class. Joined, a sibling widget's
+ * `this.value = 0.0` answers for a different widget's unsupplied `value`, and
+ * a widget FlutterFlow genuinely cannot construct passes validation.
  * @param {string} code - Source with comments and strings removed
- * @returns {string} Concatenated public widget class bodies
+ * @returns {string[]} One class body per public widget
  */
 function getPublicWidgetSpans(code) {
   const spans = [];
@@ -229,7 +236,7 @@ function getPublicWidgetSpans(code) {
     if (span) spans.push(span);
   }
 
-  return spans.join("\n");
+  return spans;
 }
 
 /**

--- a/src/flutterFlowArtifactValidation.test.js
+++ b/src/flutterFlowArtifactValidation.test.js
@@ -563,3 +563,83 @@ test("still flags a non-nullable field no constructor supplies", () => {
 
   assert.deepEqual(findings.map((finding) => finding.id), ["non-nullable-public-field"]);
 });
+
+test("a sibling widget's default does not rescue another widget's unsupplied field", () => {
+  const findings = getWidgetRuleFindings(`
+    class PriceTag extends StatefulWidget {
+      const PriceTag({super.key, this.width});
+      final double? width;
+      final double value;
+      @override
+      State<PriceTag> createState() => _PriceTagState();
+    }
+    class PriceSlider extends StatefulWidget {
+      const PriceSlider({super.key, this.value = 1.0});
+      final double value;
+      @override
+      State<PriceSlider> createState() => _PriceSliderState();
+    }
+  `);
+
+  assert.deepEqual(findings.map((finding) => finding.id), ["non-nullable-public-field"]);
+});
+
+test("a sibling widget's initializer list does not rescue another widget's field either", () => {
+  const findings = getWidgetRuleFindings(`
+    class BadgeA extends StatefulWidget {
+      const BadgeA({super.key});
+      final int count;
+      @override
+      State<BadgeA> createState() => _BadgeAState();
+    }
+    class BadgeB extends StatefulWidget {
+      const BadgeB({super.key}) : count = 3;
+      final int count;
+      @override
+      State<BadgeB> createState() => _BadgeBState();
+    }
+  `);
+
+  assert.deepEqual(findings.map((finding) => finding.id), ["non-nullable-public-field"]);
+});
+
+test("two public widgets that are each individually sound stay clean", () => {
+  const findings = getWidgetRuleFindings(`
+    class PriceTag extends StatefulWidget {
+      const PriceTag({super.key, this.value = 0.0});
+      final double value;
+      @override
+      State<PriceTag> createState() => _PriceTagState();
+    }
+    class PriceSlider extends StatefulWidget {
+      const PriceSlider({super.key, this.value});
+      final double? value;
+      @override
+      State<PriceSlider> createState() => _PriceSliderState();
+    }
+  `);
+
+  assert.deepEqual(findings, []);
+});
+
+test("required in one public widget is flagged even when a sibling is clean", () => {
+  const findings = getWidgetRuleFindings(`
+    class CleanOne extends StatefulWidget {
+      const CleanOne({super.key, this.width});
+      final double? width;
+      @override
+      State<CleanOne> createState() => _CleanOneState();
+    }
+    class BrokenOne extends StatefulWidget {
+      const BrokenOne({super.key, required this.label});
+      final String label;
+      @override
+      State<BrokenOne> createState() => _BrokenOneState();
+    }
+  `);
+
+  assert.deepEqual(findings.map((finding) => finding.id).sort(), [
+    "non-nullable-public-field",
+    "required-public-param",
+  ]);
+});

--- a/src/flutterFlowArtifactValidation.test.js
+++ b/src/flutterFlowArtifactValidation.test.js
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  calibrateWidgetRules,
   getCustomActionReturnType,
+  getWidgetRuleFindings,
   validateArtifactCompatibility,
   validateBundleCompatibility,
 } from "./flutterFlowArtifactValidation.js";
@@ -355,4 +357,164 @@ test("emits custom code file deploy hint for custom classes", () => {
       pathHint: "custom_code/",
     },
   ]);
+});
+
+test("every widget rule flags its positive control and stays silent on its negative one", () => {
+  const broken = calibrateWidgetRules().filter((result) => !result.usable);
+
+  assert.deepEqual(
+    broken,
+    [],
+    `VOID rule(s) - their silence proves nothing: ${broken.map((r) => r.id).join(", ")}`,
+  );
+});
+
+test("flags a required widget parameter FlutterFlow can leave unset", () => {
+  const findings = getWidgetRuleFindings(`
+    class AnimatedCustomSlider extends StatefulWidget {
+      const AnimatedCustomSlider({
+        super.key,
+        this.width,
+        this.height,
+        required this.value,
+      });
+      final double? width;
+      final double? height;
+      final double value;
+      @override
+      State<AnimatedCustomSlider> createState() => _AnimatedCustomSliderState();
+    }
+  `);
+
+  assert.deepEqual(
+    findings.map((finding) => finding.id).sort(),
+    ["non-nullable-public-field", "required-public-param"],
+  );
+  assert.ok(findings.every((finding) => finding.severity === "error"));
+});
+
+test("accepts a non-nullable widget field that has a constructor default", () => {
+  const findings = getWidgetRuleFindings(`
+    class QuantityStepper extends StatefulWidget {
+      const QuantityStepper({super.key, this.width, this.height, this.step = 1});
+      final double? width;
+      final double? height;
+      final int step;
+      @override
+      State<QuantityStepper> createState() => _QuantityStepperState();
+    }
+  `);
+
+  assert.deepEqual(findings, []);
+});
+
+test("ignores required on private helpers and non-widget classes", () => {
+  const findings = getWidgetRuleFindings(`
+    class _RingPainter extends CustomPainter {
+      const _RingPainter({required this.progress});
+      final double progress;
+    }
+    class _Row extends StatelessWidget {
+      const _Row({required this.label});
+      final String label;
+      @override
+      Widget build(BuildContext context) => Text(label);
+    }
+    class ProgressRing extends StatefulWidget {
+      const ProgressRing({super.key, this.width, this.height, this.progress});
+      final double? width;
+      final double? height;
+      final double? progress;
+      @override
+      State<ProgressRing> createState() => _ProgressRingState();
+    }
+  `);
+
+  assert.deepEqual(findings, []);
+});
+
+test("does not mistake required in a comment or string for a real parameter", () => {
+  const findings = getWidgetRuleFindings(`
+    class NoteCard extends StatefulWidget {
+      // const NoteCard({required this.title});
+      const NoteCard({super.key, this.title});
+      final String? title;
+      final String hint = "required this.title";
+      @override
+      State<NoteCard> createState() => _NoteCardState();
+    }
+  `);
+
+  assert.deepEqual(findings, []);
+});
+
+test("flags Image.asset fed by a String path parameter", () => {
+  const findings = getWidgetRuleFindings(`
+    class FadeInRoundedImage extends StatefulWidget {
+      const FadeInRoundedImage({super.key, this.width, this.height, this.imagePath});
+      final double? width;
+      final double? height;
+      final String? imagePath;
+      @override
+      State<FadeInRoundedImage> createState() => _FadeInRoundedImageState();
+    }
+    class _FadeInRoundedImageState extends State<FadeInRoundedImage> {
+      @override
+      Widget build(BuildContext context) => Image.asset(widget.imagePath!);
+    }
+  `);
+
+  assert.deepEqual(findings.map((finding) => finding.id), ["asset-without-anchor"]);
+  assert.equal(findings[0].severity, "warning");
+});
+
+test("does not flag a network image fed by a String path parameter", () => {
+  const findings = getWidgetRuleFindings(`
+    class RemoteImage extends StatefulWidget {
+      const RemoteImage({super.key, this.imagePath});
+      final String? imagePath;
+      @override
+      State<RemoteImage> createState() => _RemoteImageState();
+    }
+    class _RemoteImageState extends State<RemoteImage> {
+      @override
+      Widget build(BuildContext context) => Image.network(widget.imagePath!);
+    }
+  `);
+
+  assert.deepEqual(findings, []);
+});
+
+test("surfaces widget rule findings as artifact errors that block a bundle", () => {
+  const result = validateBundleCompatibility({
+    artifacts: [
+      {
+        id: "custom-widget-slider",
+        artifactName: "AnimatedCustomSlider",
+        artifactType: "CustomWidget",
+        fileName: "animated_custom_slider.dart",
+        code: `class AnimatedCustomSlider extends StatefulWidget {
+          const AnimatedCustomSlider({super.key, required this.value});
+          final double value;
+          @override
+          State<AnimatedCustomSlider> createState() => _AnimatedCustomSliderState();
+        }`,
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.findings.some((finding) => /`required`/.test(finding.message)));
+});
+
+test("leaves non-widget artifacts untouched by the widget rules", () => {
+  const findings = validateArtifactCompatibility({
+    id: "custom-class-config",
+    artifactName: "AppConfig",
+    artifactType: "CustomClass",
+    fileName: "app_config.dart",
+    code: "class AppConfig { const AppConfig({required this.token}); final String token; }",
+  });
+
+  assert.deepEqual(findings, []);
 });

--- a/src/flutterFlowArtifactValidation.test.js
+++ b/src/flutterFlowArtifactValidation.test.js
@@ -518,3 +518,48 @@ test("leaves non-widget artifacts untouched by the widget rules", () => {
 
   assert.deepEqual(findings, []);
 });
+
+test("accepts a non-nullable field supplied by a constructor initializer list", () => {
+  const findings = getWidgetRuleFindings(`
+    class StepBadge extends StatefulWidget {
+      const StepBadge({super.key, this.width, this.height}) : value = 1;
+      final double? width;
+      final double? height;
+      final int value;
+      @override
+      State<StepBadge> createState() => _StepBadgeState();
+    }
+  `);
+
+  assert.deepEqual(findings, []);
+});
+
+test("accepts an initializer list that derives a non-nullable field from a nullable parameter", () => {
+  const findings = getWidgetRuleFindings(`
+    class RatingStars extends StatefulWidget {
+      const RatingStars({super.key, double? rating, this.width})
+          : value = rating ?? 0.0;
+      final double? width;
+      final double value;
+      @override
+      State<RatingStars> createState() => _RatingStarsState();
+    }
+  `);
+
+  assert.deepEqual(findings, []);
+});
+
+test("still flags a non-nullable field no constructor supplies", () => {
+  const findings = getWidgetRuleFindings(`
+    class BrokenBadge extends StatefulWidget {
+      const BrokenBadge({super.key, this.width}) : other = 1;
+      final double? width;
+      final int other;
+      final double value;
+      @override
+      State<BrokenBadge> createState() => _BrokenBadgeState();
+    }
+  `);
+
+  assert.deepEqual(findings.map((finding) => finding.id), ["non-nullable-public-field"]);
+});

--- a/src/flutterFlowHeader.js
+++ b/src/flutterFlowHeader.js
@@ -1,0 +1,63 @@
+// Generation is not deterministic about the FlutterFlow header: the same
+// prompt returns a full "// Automatic FlutterFlow imports" block on one run and
+// a bare `import 'package:flutter/material.dart';` on the next. Both are valid
+// Dart, so nothing downstream notices - but prepending our header to code that
+// already carries one produces two DO-NOT-REMOVE blocks with real code between
+// them, which is not what FlutterFlow's paste path expects.
+//
+// Normalizing here makes the deployed file identical for both shapes.
+
+const HEADER_END_MARKER = "// DO NOT REMOVE OR MODIFY THE CODE ABOVE!";
+
+/**
+ * Reads the URI out of an import line, e.g. "package:flutter/material.dart".
+ * Matching on the URI rather than the whole line is deliberate: FlutterFlow's
+ * real header carries trailing comments ("// Imports other custom widgets")
+ * that generated code omits, so a line-equality filter leaves duplicates behind.
+ * @param {string} line - A single source line
+ * @returns {string|null} Import URI, or null when the line is not an import
+ */
+function readImportUri(line) {
+  return (/^\s*import\s+['"]([^'"]+)['"]/.exec(line) || [])[1] || null;
+}
+
+/**
+ * Drops a FlutterFlow header the generator already emitted, so the caller can
+ * apply exactly one.
+ * @param {string} code - Dart source
+ * @returns {string} Source with any leading FlutterFlow header removed
+ */
+export function stripFlutterFlowHeader(code = "") {
+  const markerIndex = code.indexOf(HEADER_END_MARKER);
+  if (markerIndex === -1) return code;
+
+  // The blank lines separating header from body belong to the header, so the
+  // caller controls that spacing when it reapplies one.
+  return code.slice(markerIndex + HEADER_END_MARKER.length).replace(/^\s*\n/, "");
+}
+
+/**
+ * Applies exactly one FlutterFlow header to generated code, whether or not the
+ * generator emitted one, and removes body imports the header already provides.
+ * @param {string} code - Dart source
+ * @param {string} header - The FlutterFlow header for this code type
+ * @returns {string} Header followed by the deduplicated body
+ */
+export function applyFlutterFlowHeader(code = "", header = "") {
+  const body = stripFlutterFlowHeader(code);
+  const headerUris = new Set(
+    (header.match(/^\s*import .*$/gm) || []).map(readImportUri).filter(Boolean),
+  );
+
+  const dedupedBody = body
+    .split("\n")
+    .filter((line) => {
+      const uri = readImportUri(line);
+      return uri === null || !headerUris.has(uri);
+    })
+    .join("\n")
+    .replace(/^\s*\/\/ Automatic FlutterFlow imports\s*$/m, "")
+    .replace(/^\s*\n+/, "");
+
+  return header + dedupedBody;
+}

--- a/src/flutterFlowHeader.js
+++ b/src/flutterFlowHeader.js
@@ -36,6 +36,14 @@ export function stripFlutterFlowHeader(code = "") {
   return code.slice(markerIndex + HEADER_END_MARKER.length).replace(/^\s*\n/, "");
 }
 
+// An unqualified `import 'uri';` is the only form the header's own import can
+// substitute for. A prefixed or filtered import binds names the header does not
+// provide, so dropping it as a duplicate breaks the file: remove
+// `import 'package:flutter/material.dart' as material;` and every `material.`
+// reference stops resolving. A repeated import is legal Dart anyway, so keeping
+// these costs nothing.
+const PLAIN_IMPORT = /^\s*import\s+['"][^'"]+['"]\s*;\s*(?:\/\/.*)?$/;
+
 /**
  * Applies exactly one FlutterFlow header to generated code, whether or not the
  * generator emitted one, and removes body imports the header already provides.
@@ -53,7 +61,8 @@ export function applyFlutterFlowHeader(code = "", header = "") {
     .split("\n")
     .filter((line) => {
       const uri = readImportUri(line);
-      return uri === null || !headerUris.has(uri);
+      if (uri === null || !headerUris.has(uri)) return true;
+      return !PLAIN_IMPORT.test(line);
     })
     .join("\n")
     .replace(/^\s*\/\/ Automatic FlutterFlow imports\s*$/m, "")

--- a/src/flutterFlowHeader.test.js
+++ b/src/flutterFlowHeader.test.js
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { applyFlutterFlowHeader, stripFlutterFlowHeader } from "./flutterFlowHeader.js";
+
+const WIDGET_HEADER = `// Automatic FlutterFlow imports
+import '/flutter_flow/flutter_flow_theme.dart';
+import '/flutter_flow/flutter_flow_util.dart';
+import 'package:flutter/material.dart';
+// Begin custom widget code
+// DO NOT REMOVE OR MODIFY THE CODE ABOVE!
+
+`;
+
+test("leaves code without a header untouched when stripping", () => {
+  const code = "class Widget extends StatefulWidget {}";
+
+  assert.equal(stripFlutterFlowHeader(code), code);
+});
+
+test("removes a header the generator already emitted", () => {
+  const code = `${WIDGET_HEADER}class Widget extends StatefulWidget {}`;
+
+  assert.equal(stripFlutterFlowHeader(code), "class Widget extends StatefulWidget {}");
+});
+
+test("both generation shapes produce byte-identical deploy content", () => {
+  const withHeader = `${WIDGET_HEADER}class Widget extends StatefulWidget {}`;
+  const bare = "import 'package:flutter/material.dart';\n\nclass Widget extends StatefulWidget {}";
+
+  assert.equal(
+    applyFlutterFlowHeader(withHeader, WIDGET_HEADER),
+    applyFlutterFlowHeader(bare, WIDGET_HEADER),
+  );
+});
+
+test("applies exactly one header", () => {
+  const result = applyFlutterFlowHeader(
+    `${WIDGET_HEADER}class Widget extends StatefulWidget {}`,
+    WIDGET_HEADER,
+  );
+
+  assert.equal(result.match(/DO NOT REMOVE OR MODIFY THE CODE ABOVE!/g).length, 1);
+  assert.equal(result.match(/\/\/ Automatic FlutterFlow imports/g).length, 1);
+});
+
+test("drops body imports the header already provides", () => {
+  const result = applyFlutterFlowHeader(
+    "import 'package:flutter/material.dart';\nimport 'package:qr_flutter/qr_flutter.dart';\n\nclass W {}",
+    WIDGET_HEADER,
+  );
+
+  assert.equal(result.match(/package:flutter\/material\.dart/g).length, 1);
+  assert.ok(result.includes("import 'package:qr_flutter/qr_flutter.dart';"));
+});
+
+test("matches header imports by URI even when the header carries trailing comments", () => {
+  const commentedHeader = `// Automatic FlutterFlow imports
+import '/custom_code/actions/index.dart'; // Imports custom actions
+// DO NOT REMOVE OR MODIFY THE CODE ABOVE!
+
+`;
+  const result = applyFlutterFlowHeader(
+    "import '/custom_code/actions/index.dart';\n\nclass W {}",
+    commentedHeader,
+  );
+
+  assert.equal(result.match(/custom_code\/actions\/index\.dart/g).length, 1);
+});
+
+test("keeps a package import that only shares a prefix with a header import", () => {
+  const result = applyFlutterFlowHeader(
+    "import 'package:flutter/material_extras.dart';\n\nclass W {}",
+    WIDGET_HEADER,
+  );
+
+  assert.ok(result.includes("package:flutter/material_extras.dart"));
+});

--- a/src/flutterFlowHeader.test.js
+++ b/src/flutterFlowHeader.test.js
@@ -75,3 +75,30 @@ test("keeps a package import that only shares a prefix with a header import", ()
 
   assert.ok(result.includes("package:flutter/material_extras.dart"));
 });
+
+test("keeps a prefixed import of a URI the header also provides", () => {
+  const result = applyFlutterFlowHeader(
+    "import 'package:flutter/material.dart' as material;\n\nclass W { material.Widget? w; }",
+    WIDGET_HEADER,
+  );
+
+  assert.ok(result.includes("import 'package:flutter/material.dart' as material;"));
+});
+
+test("keeps a show/hide import of a URI the header also provides", () => {
+  const result = applyFlutterFlowHeader(
+    "import 'package:flutter/material.dart' show Colors;\n\nclass W {}",
+    WIDGET_HEADER,
+  );
+
+  assert.ok(result.includes("show Colors"));
+});
+
+test("still drops a plain duplicate that carries a trailing comment", () => {
+  const result = applyFlutterFlowHeader(
+    "import 'package:flutter/material.dart'; // needed\n\nclass W {}",
+    WIDGET_HEADER,
+  );
+
+  assert.equal(result.match(/package:flutter\/material\.dart/g).length, 1);
+});


### PR DESCRIPTION
## Why

A user probed the pipeline with a [conformance harness](https://gist.github.com/DanLika/1b775045a4869bddc09a014cec7cfd1d) and found that a slider we generated had `required this.value` plus two non-nullable `double` params — and our review step called it clean.

They were right, and the cause is structural. Everything expensive in `flutterFlowArtifactValidation.js` (comment/string stripping, the balanced-generic reader, `SUPPORTED_RETURN_TYPES`) sits on the **CustomAction** path. The entire CustomWidget branch was one regex checking the class extends `Stateless/StatefulWidget`. Zero checks touched parameter nullability or asset references across all 382 lines.

## The mechanism

FlutterFlow **omits** unset Define Parameters fields from the constructor call it emits — it does not pass null. So `required`, or a non-nullable field with no default, makes that call fail to compile and the widget cannot be placed at all.

This is proven here, not asserted. `scripts/audit-ff-widget.mjs --self-test` against a real export:

```
hard_required.dart    HARD FAIL — `HardRequired()` does not compile     control PASS
soft_defaulted.dart   blank panel OK, null binding fails               control PASS
clean_nullable.dart   compiles blank and with all params null          control PASS
blocked_garbage.dart  stage-1 errors block stage 2 (no greenwash)      control PASS
isolation (live export untouched)                                      PASS
```

## What's here

**Three rules on the CustomWidget branch**, scoped to public `Stat*Widget` classes so helper painters keep using `required` legitimately:

| rule | severity |
|---|---|
| `required-public-param` | error |
| `non-nullable-public-field` (a constructor default is a rescue, not a defect) | error |
| `asset-without-anchor` — `Image.asset` fed by a String path param (FF issues [522](https://github.com/FlutterFlow/flutterflow-issues/issues/522), [2271](https://github.com/FlutterFlow/flutterflow-issues/issues/2271), [3799](https://github.com/FlutterFlow/flutterflow-issues/issues/3799)) | warning |

**Rule self-calibration.** Each rule carries a positive control it must flag and a negative one it must not, checked at load. A rule broken by a later edit is suppressed and reported VOID rather than silently passing every widget — we had 109 green tests and no runtime proof a shipped rule was still wired in.

**Header normalization** (`src/flutterFlowHeader.js`). Generation is not deterministic about the FlutterFlow header — the same prompt returns the full block on one run and a bare `material.dart` import on the next — and `prepareCodeForCommit` prepended ours *unconditionally*. That produced two DO-NOT-REMOVE blocks with real code between them on the first shape, and a duplicated import on the second. Both shapes now normalize to identical bytes.

**`scripts/audit-ff-widget.mjs`** (`npm run audit:widget`), adapted from the reporter's harness with attribution. It **imports** the shipped rules instead of copying them, so the dev tool and the deploy gate cannot drift. Its own self-test caught a defect in itself first: the hardcoded header imports `/backend/schema/structs/index.dart`, absent from exports with no Data Types, so it was manufacturing an error and blaming the widget. Now built from the export.

**API key out of argv for `flutterflow ai init`.** Process arguments are readable from any process listing and routinely land in logs; a FlutterFlow key carries full project write access. Verified against `flutterflow_cli` 0.0.39 rather than assumed:

- `FF_API_KEY` **is** read (`ai_router.dart:307`), and init deliberately does *not* persist an env-sourced key.
- `FLUTTERFLOW_API_KEY` is read **nowhere** — it was always inert.
- `ai run` / `ai validate` are passthrough to a vendored SDK not on disk, so env support there is unverifiable locally. Those keep `--api-key` with a comment explaining why removing it on assumption would either break every deploy or silently fall through to a key left by an earlier request.

## Not fixed here

`server.dart:57` uses **one shared workspace** for every request, and `_ensureWorkspace` skips init once it exists. Today the explicit `--api-key` on each run is what guarantees the right key is used. Concurrent requests also race on the same DSL script path (`:420`). Architectural, out of scope for this PR, flagged for a follow-up.

## Verification

144/144 tests pass. Harness self-test green against a real export, including isolation.

Backend counterpart (prompt rules): `sgardoll/buildship#feat/widget-conformance-rules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)