### PR TITLE
fix: align review contract with BuildShip and harden deploy placement

### DIFF
--- a/src/artifactBundle.js
+++ b/src/artifactBundle.js
@@ -1,5 +1,8 @@
-const DEFAULT_ARTIFACT_TYPE = "CustomWidget";
-const DEFAULT_ARTIFACT_NAME = "GeneratedWidget";
+// A missing artifactType must not silently become a CustomWidget (which would
+// misroute a class/function into lib/custom_code/widgets). Standalone code
+// files under lib/custom_code/ is the safe default.
+const DEFAULT_ARTIFACT_TYPE = "CodeFile";
+const DEFAULT_ARTIFACT_NAME = "GeneratedCode";
 
 const ARTIFACT_TYPE_TO_CODE_TYPE = {
   CustomAction: "A",
@@ -47,6 +50,7 @@ export function normalizeArtifact(rawArtifact = {}, index = 0) {
     artifactType,
     artifactName,
     fileName,
+    deployPath: artifact.deployPath || "",
     description: artifact.description || "",
     code: artifact.code || artifact.content || "",
     dependencies: normalizeDependencies(artifact.dependencies),
@@ -148,6 +152,13 @@ export function normalizeArtifactBundle(input, options = {}) {
         },
       ];
 
+  rawArtifacts.forEach((raw, index) => {
+    if (!raw?.artifactType && !raw?.type) {
+      warnings.push(
+        `Artifact ${index + 1} has no artifactType; it will deploy as a standalone code file under lib/custom_code/ root.`,
+      );
+    }
+  });
   const artifacts = rawArtifacts.map((artifact, index) => normalizeArtifact(artifact, index));
   const idMap = new Map(
     rawArtifacts

--- a/src/bundleDeployPlanner.js
+++ b/src/bundleDeployPlanner.js
@@ -85,7 +85,7 @@ export function buildBundleDeployPlan(bundle, options = {}) {
     .filter(Boolean);
 
   const warnings = [...(bundle?.warnings || [])];
-  const fileEntries = [];
+  let fileEntries = [];
 
   selected.forEach((artifact) => {
     const fileName = toFileName(artifact);
@@ -101,10 +101,36 @@ export function buildBundleDeployPlan(bundle, options = {}) {
       fileName,
       content,
       type: codeType,
-      path: getBundleFilePath(fileName, codeType),
+      // An explicit deployPath from the pipeline contract wins; otherwise the
+      // path is inferred from the artifact type.
+      path: artifact.deployPath || getBundleFilePath(fileName, codeType),
+      deployPath: artifact.deployPath || "",
       deployMode: "customCodeSync",
     });
   });
+
+  // FlutterFlow keeps every custom function in the single shared file
+  // lib/flutter_flow/custom_functions.dart. Multiple function artifacts must
+  // merge into that one entry rather than colliding, which previously blocked
+  // the deploy with a duplicate-path error or silently dropped functions.
+  const SHARED_FUNCTIONS_PATH = "lib/flutter_flow/custom_functions.dart";
+  const functionEntries = fileEntries
+    .map((entry, index) => ({ entry, index }))
+    .filter(({ entry }) => entry.type === CODE_TYPE.FUNCTION && entry.path === SHARED_FUNCTIONS_PATH);
+  if (functionEntries.length > 1) {
+    const first = functionEntries[0];
+    const merged = {
+      ...first.entry,
+      artifactId: functionEntries.map(({ entry }) => entry.artifactId).join("+"),
+      artifactName: first.entry.artifactName,
+      content: functionEntries
+        .map(({ entry }) => `// ${entry.artifactId}\n${entry.content}`)
+        .join("\n\n"),
+    };
+    const laterIndexes = new Set(functionEntries.slice(1).map(({ index }) => index));
+    fileEntries = fileEntries.filter((_, index) => !laterIndexes.has(index));
+    fileEntries[first.index] = merged;
+  }
 
   const declaredDependencies = {
     ...toDependencyMap(bundle?.dependencies),

--- a/src/bundleDeployPlanner.test.js
+++ b/src/bundleDeployPlanner.test.js
@@ -66,7 +66,7 @@ test("uses FlutterFlow custom functions file for function artifacts", () => {
   assert.equal(plan.fileEntries[0].type, "F");
 });
 
-test("blocks duplicate deploy targets before file map construction", () => {
+test("merges multiple function artifacts into the shared custom_functions.dart", () => {
   const plan = buildBundleDeployPlan({
     artifacts: [
       {
@@ -84,8 +84,37 @@ test("blocks duplicate deploy targets before file map construction", () => {
     ],
   });
 
-  assert.equal(plan.fileEntries.length, 2);
-  assert.equal(plan.errors.length, 2);
-  assert.match(plan.errors[0], /Duplicate deploy file name "custom_functions\.dart"/);
-  assert.match(plan.errors[1], /Duplicate deploy path "lib\/flutter_flow\/custom_functions\.dart"/);
+  assert.equal(plan.fileEntries.length, 1);
+  assert.equal(plan.fileEntries[0].fileName, "custom_functions.dart");
+  assert.equal(plan.fileEntries[0].path, "lib/flutter_flow/custom_functions.dart");
+  assert.match(plan.fileEntries[0].content, /formatA/);
+  assert.match(plan.fileEntries[0].content, /formatB/);
+  assert.equal(plan.errors.length, 0);
+});
+
+test("honors an explicit deployPath and still flags true duplicate targets", () => {
+  const plan = buildBundleDeployPlan({
+    artifacts: [
+      {
+        id: "widget-a",
+        artifactType: "CustomWidget",
+        artifactName: "WidgetA",
+        fileName: "widget_a.dart",
+        deployPath: "lib/custom_code/actions/override_a.dart",
+        code: "class WidgetA extends StatelessWidget {}",
+      },
+      {
+        id: "widget-b",
+        artifactType: "CustomWidget",
+        artifactName: "WidgetB",
+        fileName: "widget_b.dart",
+        deployPath: "lib/custom_code/actions/override_a.dart",
+        code: "class WidgetB extends StatelessWidget {}",
+      },
+    ],
+  });
+
+  assert.equal(plan.fileEntries[0].path, "lib/custom_code/actions/override_a.dart");
+  assert.equal(plan.errors.length, 1);
+  assert.match(plan.errors[0], /Duplicate deploy path/);
 });

--- a/src/flutterFlowArtifactValidation.js
+++ b/src/flutterFlowArtifactValidation.js
@@ -7,9 +7,9 @@ const SUPPORTED_TYPES = new Set([
 ]);
 
 const TYPE_FILE_HINTS = {
-  CustomWidget: "custom_widgets/",
-  CustomAction: "actions/",
-  CustomFunction: "custom_functions/",
+  CustomWidget: "custom_code/widgets/",
+  CustomAction: "custom_code/actions/",
+  CustomFunction: "flutter_flow/custom_functions.dart",
   CustomClass: "custom_code/",
   CodeFile: "custom_code/",
 };

--- a/src/flutterFlowArtifactValidation.test.js
+++ b/src/flutterFlowArtifactValidation.test.js
@@ -332,7 +332,7 @@ test("validates a bundle and emits deploy path hints", () => {
     {
       artifactId: "custom-function-format",
       fileName: "format_thing.dart",
-      pathHint: "custom_functions/",
+      pathHint: "flutter_flow/custom_functions.dart",
     },
   ]);
 });

--- a/src/pipelineContracts.js
+++ b/src/pipelineContracts.js
@@ -39,7 +39,7 @@ export function buildReviewPrompt(generatedBundle) {
     task: "review_bundle",
     generatedBundle: parseJsonIfPossible(generatedBundle),
     outputRequirements: {
-      overall: ["status", "score", "summary", "findings"],
+      bundleReview: ["status", "score", "summary", "findings"],
       scoreRange: [0, 100],
       eachArtifact: ["id", "review.status", "review.findings"],
     },

--- a/src/pipelineContracts.js
+++ b/src/pipelineContracts.js
@@ -39,7 +39,7 @@ export function buildReviewPrompt(generatedBundle) {
     task: "review_bundle",
     generatedBundle: parseJsonIfPossible(generatedBundle),
     outputRequirements: {
-      bundleReview: ["status", "score", "summary", "findings"],
+      bundleReview: ["status", "score", "summary", "manualActions", "findings"],
       scoreRange: [0, 100],
       eachArtifact: ["id", "review.status", "review.findings"],
     },

--- a/src/pipelineContracts.test.js
+++ b/src/pipelineContracts.test.js
@@ -36,7 +36,7 @@ test("review prompt sends generated bundle data without system instructions", ()
 
   assert.equal(payload.task, "review_bundle");
   assert.equal(payload.generatedBundle.artifacts[0].id, "action-a");
-  assert.deepEqual(payload.outputRequirements.overall, [
+  assert.deepEqual(payload.outputRequirements.bundleReview, [
     "status",
     "score",
     "summary",
@@ -49,7 +49,6 @@ test("review prompt sends generated bundle data without system instructions", ()
     "review.findings",
   ]);
   assert.doesNotMatch(prompt, /Review every generated artifact/);
-  assert.doesNotMatch(prompt, /bundleReview/);
 });
 
 test("BuildShip context only sends runtime state", () => {

--- a/src/pipelineContracts.test.js
+++ b/src/pipelineContracts.test.js
@@ -40,6 +40,7 @@ test("review prompt sends generated bundle data without system instructions", ()
     "status",
     "score",
     "summary",
+    "manualActions",
     "findings",
   ]);
   assert.deepEqual(payload.outputRequirements.scoreRange, [0, 100]);

--- a/src/reviewPresentation.js
+++ b/src/reviewPresentation.js
@@ -258,6 +258,36 @@ function buildArtifactPresentation(bundle, reviewArtifacts, artifact, index) {
   };
 }
 
+/**
+ * Builds a deployable, user-actionable summary when the review returned no
+ * written summary. Never falls back to a useless placeholder: it synthesizes
+ * the verdict, per-artifact pass/warn/fail counts, and the manual steps the
+ * user must take in their own FlutterFlow project, and calls out when no
+ * numeric score was returned so a missing score is never mistaken for a pass.
+ */
+function buildFallbackSummary({ status, score, artifactPresentations, manualSteps }) {
+  const total = artifactPresentations.length;
+  if (total === 0 && manualSteps.length === 0) {
+    return score == null
+      ? "Code review returned no overall summary and no score."
+      : `Reviewed bundle with score ${score}/100.`;
+  }
+  const counts = artifactPresentations.reduce((result, artifact) => {
+    result[artifact.status] += 1;
+    return result;
+  }, { pass: 0, warning: 0, fail: 0 });
+  const parts = [];
+  if (status) parts.push(`Overall verdict: ${status}.`);
+  if (total) {
+    parts.push(`${total} artifact${total === 1 ? "" : "s"}: ${counts.pass} pass, ${counts.warning} warn, ${counts.fail} fail.`);
+  }
+  if (manualSteps.length) {
+    parts.push(`Do before deploy: ${manualSteps.map((step) => step.title).join("; ")}.`);
+  }
+  if (score == null) parts.push("No numeric score (0-100) was returned.");
+  return parts.join(" ");
+}
+
 export function buildReviewPresentation({ bundle, reviewResult }) {
   const safeBundle = toObject(bundle);
   const artifacts = asArray(safeBundle.artifacts);
@@ -320,8 +350,7 @@ export function buildReviewPresentation({ bundle, reviewResult }) {
     root.assessment,
     root.conclusion,
     rawText,
-    safeBundle.description,
-  ) || "Code Review completed without an overarching written summary.";
+  ) || buildFallbackSummary({ status, score: scoreValue, artifactPresentations, manualSteps });
   const counts = artifactPresentations.reduce((result, artifact) => {
     result[artifact.status] += 1;
     return result;

--- a/src/reviewPresentation.test.js
+++ b/src/reviewPresentation.test.js
@@ -238,3 +238,43 @@ test("falls back from malformed bundleReview to a valid overallReview", () => {
     assert.equal(presentation.findings[0].message, "The bundle structure is valid.");
   }
 });
+
+test("synthesizes an actionable summary and flags a missing score when none is returned", () => {
+  const presentation = buildReviewPresentation({
+    bundle,
+    reviewResult: JSON.stringify({
+      bundleReview: {
+        status: "warn",
+        manualActions: [{ title: "Add the http package to Project Dependencies" }],
+        findings: [{ severity: "warning", message: "Confirm endpoint auth." }],
+      },
+      artifacts: [
+        { id: "format_payload", review: { status: "pass", findings: [] } },
+        { id: "execute_webhook", review: { status: "warn", findings: [] } },
+      ],
+    }),
+  });
+
+  assert.equal(presentation.score, null);
+  assert.match(presentation.summary, /Overall verdict: warn/i);
+  assert.match(presentation.summary, /1 pass, 1 warn, 0 fail/);
+  assert.match(presentation.summary, /Add the http package/);
+  assert.match(presentation.summary, /No numeric score/);
+  assert.doesNotMatch(presentation.summary, /overarching written summary/);
+});
+
+test("keeps a supplied score and written summary verbatim", () => {
+  const presentation = buildReviewPresentation({
+    bundle,
+    reviewResult: JSON.stringify({
+      bundleReview: {
+        status: "pass",
+        score: 96,
+        summary: "Safe to deploy after adding the http dependency.",
+      },
+    }),
+  });
+
+  assert.equal(presentation.score, 96);
+  assert.equal(presentation.summary, "Safe to deploy after adding the http dependency.");
+});


### PR DESCRIPTION
Fixes two symptoms against the runPipeline backend: an empty review summary, code artifacts landing in the wrong FlutterFlow folder, and makes the review score + deploy guide mandatory on every generation.

**Review (must ship every time):**
- `buildReviewPrompt`: request `bundleReview` as {status, score, summary, manualActions, findings} so the request matches what the parser reads and what BuildShip's system prompt now requires.
- `reviewPresentation`: a missing written summary no longer falls back to the bundle description or a useless placeholder. It synthesizes an actionable deploy guide (verdict, per-artifact pass/warn/fail counts, the manual steps to take in the user's own FlutterFlow project) and explicitly flags when no numeric 0-100 score was returned, so a missing score is never mistaken for a pass.
- score + summary are enforced on the BuildShip prompt side (see paired PR) — there is no valid review without them.

**Placement:**
- `normalizeArtifact`: a missing `artifactType` no longer silently becomes a `CustomWidget` (misrouting classes/functions into `lib/custom_code/widgets/`); it defaults to a standalone code file (lib/custom_code/ root) and surfaces a warning. Honors `artifact.deployPath`.
- `bundleDeployPlanner`: honors `deployPath`; merges multiple `CustomFunction` artifacts into the single shared `lib/flutter_flow/custom_functions.dart` (verified as FlutterFlow's real layout) instead of erroring on a duplicate-path collision.
- `flutterFlowArtifactValidation`: corrected `TYPE_FILE_HINTS` to the real exported layout.

**Pre-existing project state is preserved (not overwritten):**
- Custom functions: the push uses FlutterFlow's `functions_map` and diffs generated function names against the real exported `custom_functions.dart` (`functions_to_add` = new names only, never delete), so functions already in the user's project stay.
- pubspec.yaml: `resolveProjectPubspec` reads the real remote pubspec and only merges in the generated packages; it aborts rather than overwrite if the project pubspec can't be read.

Paired with https://github.com/sgardoll/buildship/pull/62. All 159 tests pass.